### PR TITLE
fix(build): replace global workspace injection with legacy pnpm deploy

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-inject-workspace-packages=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 COPY . .
 RUN CI=true pnpm install --frozen-lockfile
 RUN pnpm build
-RUN pnpm deploy --filter-prod=server --prod /prod/server
+RUN pnpm deploy --filter-prod=server --prod --legacy /prod/server
 
 FROM base AS runner
 RUN groupadd --system --gid 1001 nodejs && \

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,7 +3,6 @@ lockfileVersion: '9.0'
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
-  injectWorkspacePackages: true
 
 importers:
 


### PR DESCRIPTION
## Problem

`inject-workspace-packages=true` (added in #85 to satisfy the Docker `pnpm deploy` step) makes pnpm hard-link **copies** of workspace packages into their consumers at install time.

The copy of `@athena/api` is snapshotted **before** its `dist/` output exists. Once the setting takes effect, `tsc` in `server`/`web` can no longer resolve `@athena/api`:

```
server:build: error TS2307: Cannot find module '@athena/api'
```

The setting has been dormant only because `main`'s lockfile predates it and still records plain `link:` (symlink) wiring — CI's `--frozen-lockfile` install never re-resolves. **Any** lockfile regeneration (e.g. a Dependabot bump) activates injection and breaks the build. This is exactly what sank PR #92.

## Fix

Scope the bundling need to the one place that actually has it — the Docker `pnpm deploy` step:

- **Remove `inject-workspace-packages=true`** (delete `.npmrc`). CI and local dev return to plain workspace symlinks, so a package's `dist/` is visible to consumers the moment it's built.
- **`pnpm deploy --legacy`** in the `Dockerfile` — produces the same self-contained prod bundle without requiring globally injected dependencies (`--legacy` is pnpm 9's normal deploy behavior; pnpm 10 only changed the *default*).
- **`pnpm-lock.yaml`** — drops the now-stale `settings.injectWorkspacePackages` entry (one line).

## Verification

Locally, with a clean `pnpm install --frozen-lockfile`:

- `pnpm build` — 3/3 ✅
- `turbo lint -- --max-warnings=0` — 3/3 ✅
- `pnpm deploy --filter-prod=server --prod --legacy` — produces a bundle whose `node_modules/@athena/api` correctly includes `dist/` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
