### PR TITLE
fix(build): install native build tools for node-gyp in Docker builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,11 @@ RUN npm install -g corepack@latest --force
 RUN corepack enable
 
 FROM base AS builder
+# Build tools for native modules (e.g. better-sqlite3) that lack prebuilt
+# binaries for the current Node version and fall back to node-gyp.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends python3 make g++ && \
+    rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY . .
 RUN CI=true pnpm install --frozen-lockfile


### PR DESCRIPTION
## Problem

The CI image build fails on `RUN CI=true pnpm install --frozen-lockfile`:

```
gyp ERR! find Python Could not find any Python installation to use
```

After dependabot bumped the base image from `node:25-slim` to `node:26-slim` (commit 18b75da), `better-sqlite3@12.8.0` no longer has prebuilt binaries for the Node version (`target=26.1.0`). `prebuild-install` falls back to `node-gyp rebuild`, which requires Python and a C++ toolchain — neither is present in the `slim` image.

## Fix

Install `python3`, `make` and `g++` in the builder stage so native modules can compile from source. The runner stage stays slim: it only receives the already-compiled `.node` artifacts via `pnpm deploy`.

Failing run: https://github.com/esukram/athena/actions/runs/25993760549/job/76404510910

🤖 Generated with [Claude Code](https://claude.com/claude-code)