### PR TITLE
ci(docker): validate image build on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,3 +99,22 @@ jobs:
 
       - name: Lint
         run: pnpm exec turbo lint -- --max-warnings=0
+
+  docker-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: false
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,17 @@ Testing is essential for maintaining a stable application.
 - While E2E tests are our primary focus for user journeys, unit tests for complex logic are highly encouraged.
 - Location: Co-locate test files with their source files (e.g., `Component.test.tsx` next to `Component.tsx`).
 
+### Docker Image Build
+
+The production Docker image is built and validated automatically on every pull
+request by the CI `docker-build` job. If you change the `Dockerfile`, base
+image, or a native dependency (e.g. `better-sqlite3`), verify the image builds
+locally before pushing:
+
+```bash
+pnpm docker:build
+```
+
 ## 🔢 Versioning Policy
 
 Athena follows [Semantic Versioning 2.0.0](https://semver.org/). Version numbers are structured as `MAJOR.MINOR.PATCH`:

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:e2e": "turbo test:e2e",
     "test:e2e:report": "pnpm --filter web exec playwright show-report",
     "clean": "turbo clean",
+    "docker:build": "docker build -t athena:local .",
     "prepare": "command -v git >/dev/null 2>&1 && husky || true"
   },
   "devDependencies": {


### PR DESCRIPTION
## Why

The CI image build (`Deploy to GHCR`) failed at release time because the `node:25-slim` → `node:26-slim` bump broke the `better-sqlite3` native compile (fixed in #105). The regression was invisible until a tag was pushed, because:

- `Deploy to GHCR` only runs `on: push: tags` — never on PRs.
- The `CI` workflow builds with `node-version: 20`, so it never exercised the Node 26 native-build path the image actually uses.

## Change

Detect Dockerfile / native-dependency regressions both **during the PR life-cycle** and **locally**:

- **CI** — new `docker-build` job in `.github/workflows/ci.yml` builds the image (`push: false`) on every pull request and push to `main`, with GitHub Actions layer caching.
- **Local** — new `pnpm docker:build` script to validate the image build before pushing, documented in `CONTRIBUTING.md`.

Now a broken base-image bump (including future Dependabot updates) fails CI on the PR that introduces it, instead of surfacing at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)