### PR TITLE
feat(learn): auto-advance voice playback to the next chapter

### DIFF
--- a/apps/web/src/components/AutoAdvanceToggle.test.tsx
+++ b/apps/web/src/components/AutoAdvanceToggle.test.tsx
@@ -13,7 +13,7 @@ vi.mock('react-i18next', () => ({
 describe('AutoAdvanceToggle', () => {
   it('renders the label', () => {
     render(<AutoAdvanceToggle checked={false} onChange={() => {}} />);
-    expect(screen.getByText('speech.autoAdvance')).toBeInTheDocument();
+    expect(screen.getByText('speech.autoAdvanceShort')).toBeInTheDocument();
   });
 
   it('reflects the checked prop', () => {

--- a/apps/web/src/components/AutoAdvanceToggle.test.tsx
+++ b/apps/web/src/components/AutoAdvanceToggle.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { AutoAdvanceToggle } from './AutoAdvanceToggle';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('AutoAdvanceToggle', () => {
+  it('renders the label', () => {
+    render(<AutoAdvanceToggle checked={false} onChange={() => {}} />);
+    expect(screen.getByText('speech.autoAdvance')).toBeInTheDocument();
+  });
+
+  it('reflects the checked prop', () => {
+    render(<AutoAdvanceToggle checked={true} onChange={() => {}} />);
+    expect(screen.getByRole('checkbox')).toBeChecked();
+  });
+
+  it('fires onChange with the toggled value when clicked', () => {
+    const onChange = vi.fn();
+    render(<AutoAdvanceToggle checked={false} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it('fires onChange with false when unticked', () => {
+    const onChange = vi.fn();
+    render(<AutoAdvanceToggle checked={true} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(onChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/apps/web/src/components/AutoAdvanceToggle.tsx
+++ b/apps/web/src/components/AutoAdvanceToggle.tsx
@@ -1,0 +1,34 @@
+import { useTranslation } from 'react-i18next';
+
+interface AutoAdvanceToggleProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+/**
+ * Checkbox that controls whether voice playback in Learn mode continues into the
+ * next chapter automatically once the current chapter finishes. The preference
+ * is persisted by the parent — this component is purely presentational.
+ */
+export const AutoAdvanceToggle = ({
+  checked,
+  onChange,
+}: AutoAdvanceToggleProps) => {
+  const { t } = useTranslation();
+  const label = t('speech.autoAdvance');
+
+  return (
+    <label
+      className="flex items-center gap-2 px-3 py-1.5 text-sm font-medium rounded-full bg-surface text-on-surface-variant cursor-pointer transition-colors hover:bg-primary-50"
+      title={label}
+    >
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(event) => onChange(event.target.checked)}
+        className="h-4 w-4 accent-primary-600 cursor-pointer"
+      />
+      <span className="whitespace-nowrap">{label}</span>
+    </label>
+  );
+};

--- a/apps/web/src/components/AutoAdvanceToggle.tsx
+++ b/apps/web/src/components/AutoAdvanceToggle.tsx
@@ -1,3 +1,4 @@
+import { ChevronsRight } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 interface AutoAdvanceToggleProps {
@@ -6,29 +7,41 @@ interface AutoAdvanceToggleProps {
 }
 
 /**
- * Checkbox that controls whether voice playback in Learn mode continues into the
- * next chapter automatically once the current chapter finishes. The preference
- * is persisted by the parent — this component is purely presentational.
+ * Compact icon toggle controlling whether voice playback in Learn mode continues
+ * into the next chapter automatically once the current chapter finishes. Renders
+ * icon-only by default and expands to reveal its label on hover or keyboard
+ * focus. The preference is persisted by the parent — this component is purely
+ * presentational.
  */
 export const AutoAdvanceToggle = ({
   checked,
   onChange,
 }: AutoAdvanceToggleProps) => {
   const { t } = useTranslation();
-  const label = t('speech.autoAdvance');
+  const fullLabel = t('speech.autoAdvance');
+  const shortLabel = t('speech.autoAdvanceShort');
 
   return (
     <label
-      className="flex items-center gap-2 px-3 py-1.5 text-sm font-medium rounded-full bg-surface text-on-surface-variant cursor-pointer transition-colors hover:bg-primary-50"
-      title={label}
+      className={`group relative flex items-center px-3 py-1.5 text-sm font-medium rounded-full cursor-pointer transition-all
+        ${
+          checked
+            ? 'bg-primary-100 text-primary-700'
+            : 'bg-surface text-on-surface-variant hover:bg-primary-50'
+        }`}
+      title={fullLabel}
     >
       <input
         type="checkbox"
         checked={checked}
         onChange={(event) => onChange(event.target.checked)}
-        className="h-4 w-4 accent-primary-600 cursor-pointer"
+        aria-label={fullLabel}
+        className="peer absolute inset-0 h-full w-full cursor-pointer opacity-0"
       />
-      <span className="whitespace-nowrap">{label}</span>
+      <ChevronsRight size={18} aria-hidden="true" />
+      <span className="max-w-0 overflow-hidden whitespace-nowrap opacity-0 transition-all group-hover:ml-2 group-hover:max-w-[12rem] group-hover:opacity-100 peer-focus-visible:ml-2 peer-focus-visible:max-w-[12rem] peer-focus-visible:opacity-100">
+        {shortLabel}
+      </span>
     </label>
   );
 };

--- a/apps/web/src/components/VoicePlaybackButton.tsx
+++ b/apps/web/src/components/VoicePlaybackButton.tsx
@@ -51,7 +51,7 @@ export const VoicePlaybackButton = ({
     <button
       type="button"
       onClick={onToggle}
-      className={`flex items-center gap-2 px-3 py-1.5 text-sm font-medium rounded-full transition-all hover:scale-105
+      className={`group relative flex items-center px-3 py-1.5 text-sm font-medium rounded-full transition-all
         ${
           isError
             ? 'bg-red-50 text-red-700 hover:bg-red-100'
@@ -63,7 +63,15 @@ export const VoicePlaybackButton = ({
       title={label}
     >
       {icon}
-      <span className="whitespace-nowrap">{label}</span>
+      <span
+        className={`overflow-hidden whitespace-nowrap transition-all ${
+          isError
+            ? 'ml-2 max-w-[20rem] opacity-100'
+            : 'max-w-0 opacity-0 group-hover:ml-2 group-hover:max-w-[12rem] group-hover:opacity-100 group-focus-visible:ml-2 group-focus-visible:max-w-[12rem] group-focus-visible:opacity-100'
+        }`}
+      >
+        {label}
+      </span>
     </button>
   );
 };

--- a/apps/web/src/locales/de.json
+++ b/apps/web/src/locales/de.json
@@ -129,6 +129,7 @@
     "autoPlayResume": "Vorlesen fortsetzen",
     "autoPlayLoading": "Audio wird vorbereitet...",
     "autoPlayNowPlaying": "Automatisches Vorlesen: Frage {{current}} von {{total}}",
-    "autoPlayError": "Vorlesen fehlgeschlagen – zum Wiederholen tippen"
+    "autoPlayError": "Vorlesen fehlgeschlagen – zum Wiederholen tippen",
+    "autoAdvance": "Automatisch zum nächsten Kapitel"
   }
 }

--- a/apps/web/src/locales/de.json
+++ b/apps/web/src/locales/de.json
@@ -130,6 +130,7 @@
     "autoPlayLoading": "Audio wird vorbereitet...",
     "autoPlayNowPlaying": "Automatisches Vorlesen: Frage {{current}} von {{total}}",
     "autoPlayError": "Vorlesen fehlgeschlagen – zum Wiederholen tippen",
-    "autoAdvance": "Automatisch zum nächsten Kapitel"
+    "autoAdvance": "Automatisch zum nächsten Kapitel",
+    "autoAdvanceShort": "Automatisch weiter"
   }
 }

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -129,6 +129,7 @@
     "autoPlayResume": "Resume auto-play",
     "autoPlayLoading": "Preparing audio...",
     "autoPlayNowPlaying": "Auto-play: question {{current}} of {{total}}",
-    "autoPlayError": "Auto-play failed — tap to retry"
+    "autoPlayError": "Auto-play failed — tap to retry",
+    "autoAdvance": "Auto-advance to next chapter"
   }
 }

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -130,6 +130,7 @@
     "autoPlayLoading": "Preparing audio...",
     "autoPlayNowPlaying": "Auto-play: question {{current}} of {{total}}",
     "autoPlayError": "Auto-play failed — tap to retry",
-    "autoAdvance": "Auto-advance to next chapter"
+    "autoAdvance": "Auto-advance to next chapter",
+    "autoAdvanceShort": "Auto-advance"
   }
 }

--- a/apps/web/src/pages/LectureEdit.tsx
+++ b/apps/web/src/pages/LectureEdit.tsx
@@ -57,9 +57,9 @@ export const EditLecture = () => {
   const isAutoSavingRef = useRef(false);
   // In-flight auto-save promise, resolving to the IDs of questions it created
   // (keyed by question order). A manual save awaits this to avoid duplicates.
-  const autoSavePromiseRef = useRef<Promise<Map<number, string> | undefined> | null>(
-    null,
-  );
+  const autoSavePromiseRef = useRef<Promise<
+    Map<number, string> | undefined
+  > | null>(null);
 
   // Fetch questions for the editing chapter (only for existing chapters)
   const chapterQuestionsQuery = trpc.questions.getQuestions.useQuery(

--- a/apps/web/src/pages/LectureLearn.tsx
+++ b/apps/web/src/pages/LectureLearn.tsx
@@ -2,12 +2,13 @@ import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';
 import { useNavigate, useParams } from 'react-router-dom';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import type { Chapter, Question } from '@athena/api';
 
 import { Accordion } from '../components/Accordion';
 import { AppHeader } from '../components/AppHeader';
+import { AutoAdvanceToggle } from '../components/AutoAdvanceToggle';
 import { ChapterMenu } from '../components/ChapterMenu';
 import { ChapterSidebar } from '../components/ChapterSidebar';
 import { ErrorState } from '../components/ErrorState';
@@ -25,6 +26,13 @@ export const LectureLearn = () => {
   const navigate = useNavigate();
   const [searchQuery, setSearchQuery] = useState('');
   const [isSearchOpen, setIsSearchOpen] = useState(false);
+  // Hands-free preference: continue voice playback into the next chapter.
+  const [autoAdvance, setAutoAdvance] = useState(
+    () => localStorage.getItem('learnAutoAdvance') === 'true',
+  );
+  // Set when an auto-advance navigation happens so the next chapter resumes
+  // playback once its questions have loaded.
+  const [pendingAutoStart, setPendingAutoStart] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const chapterButtonsRef = useRef<Map<number, HTMLButtonElement>>(new Map());
   const questionRefs = useRef<Map<number, HTMLDivElement>>(new Map());
@@ -42,6 +50,22 @@ export const LectureLearn = () => {
   const chapters = useMemo(
     () => chaptersQuery.data || [],
     [chaptersQuery.data],
+  );
+
+  const handleAutoAdvanceChange = (checked: boolean) => {
+    setAutoAdvance(checked);
+    localStorage.setItem('learnAutoAdvance', String(checked));
+  };
+
+  // Navigate to a chapter on explicit user intent. Clears any pending
+  // auto-start so a manual jump never triggers a surprise resume.
+  const goToChapter = useCallback(
+    (index: number) => {
+      if (index < 0 || index >= chapters.length) return;
+      setPendingAutoStart(false);
+      navigate(`/learn/${id}/${chapters[index].id}`);
+    },
+    [chapters, id, navigate],
   );
 
   // Fetch all first questions for this lecture in a single call
@@ -108,21 +132,15 @@ export const LectureLearn = () => {
       if (document.activeElement === searchInputRef.current) return;
 
       if (event.key === 'ArrowRight') {
-        const nextIndex = selectedChapterIndex + 1;
-        if (nextIndex < chapters.length) {
-          navigate(`/learn/${id}/${chapters[nextIndex].id}`);
-        }
+        goToChapter(selectedChapterIndex + 1);
       } else if (event.key === 'ArrowLeft') {
-        const prevIndex = selectedChapterIndex - 1;
-        if (prevIndex >= 0) {
-          navigate(`/learn/${id}/${chapters[prevIndex].id}`);
-        }
+        goToChapter(selectedChapterIndex - 1);
       }
     };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [chapters, selectedChapterIndex, id, navigate]);
+  }, [selectedChapterIndex, goToChapter]);
 
   // Fetch all questions for the current chapter
   const currentChapter = chapters[selectedChapterIndex];
@@ -154,6 +172,47 @@ export const LectureLearn = () => {
       .get(voiceIndex)
       ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
   }, [voiceIndex]);
+
+  // Auto-advance: when a chapter's playback finishes and the preference is on,
+  // move to the next chapter and flag it to resume playback automatically.
+  const voiceStatus = voice.status;
+  useEffect(() => {
+    if (voiceStatus !== 'finished' || !autoAdvance) return;
+    const nextIndex = selectedChapterIndex + 1;
+    if (nextIndex >= chapters.length) return;
+    setPendingAutoStart(true);
+    navigate(`/learn/${id}/${chapters[nextIndex].id}`);
+  }, [voiceStatus, autoAdvance, selectedChapterIndex, chapters, id, navigate]);
+
+  // Auto-advance follow-up: once the freshly-navigated chapter has loaded its
+  // questions, resume playback. Chapters with no questions are skipped.
+  const voiceToggle = voice.toggle;
+  const questionsLoading = currentChapterQuestionsQuery.isLoading;
+  useEffect(() => {
+    if (!pendingAutoStart || voiceStatus !== 'idle' || questionsLoading) return;
+    if (currentChapterQuestions.length > 0) {
+      setPendingAutoStart(false);
+      voiceToggle();
+      return;
+    }
+    // Empty chapter — keep advancing until one has content or we run out.
+    const nextIndex = selectedChapterIndex + 1;
+    if (nextIndex < chapters.length) {
+      navigate(`/learn/${id}/${chapters[nextIndex].id}`);
+    } else {
+      setPendingAutoStart(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    pendingAutoStart,
+    voiceStatus,
+    questionsLoading,
+    currentChapterQuestions,
+    selectedChapterIndex,
+    chapters,
+    id,
+    navigate,
+  ]);
 
   if (lectureQuery.isLoading || chaptersQuery.isLoading) {
     return <LoadingState />;
@@ -206,7 +265,7 @@ export const LectureLearn = () => {
               filteredChapters={filteredChapters}
               selectedIndex={selectedChapterIndex}
               onSelect={(chapter: Chapter) =>
-                navigate(`/learn/${id}/${chapter.id}`)
+                goToChapter(chapters.findIndex((c) => c.id === chapter.id))
               }
               isSearchOpen={isSearchOpen}
               onSearchToggle={() => {
@@ -236,15 +295,21 @@ export const LectureLearn = () => {
                     <h2 className="text-2xl font-bold text-on-background">
                       {currentFirstQuestion?.question || t('common.untitled')}
                     </h2>
-                    <div className="flex items-center gap-2">
+                    <div className="flex flex-wrap items-center gap-2">
                       {speechConfigured &&
                         currentChapterQuestions.length > 0 && (
-                          <VoicePlaybackButton
-                            status={voice.status}
-                            isActive={voice.isActive}
-                            isPaused={voice.isPaused}
-                            onToggle={voice.toggle}
-                          />
+                          <>
+                            <VoicePlaybackButton
+                              status={voice.status}
+                              isActive={voice.isActive}
+                              isPaused={voice.isPaused}
+                              onToggle={voice.toggle}
+                            />
+                            <AutoAdvanceToggle
+                              checked={autoAdvance}
+                              onChange={handleAutoAdvanceChange}
+                            />
+                          </>
                         )}
                       {currentChapter.association && (
                         <span className="px-3 py-1 text-sm font-medium bg-primary-100 text-primary-700 rounded-full">
@@ -312,16 +377,8 @@ export const LectureLearn = () => {
                   )}
 
                   <LectureNavigation
-                    onPrev={() =>
-                      navigate(
-                        `/learn/${id}/${chapters[selectedChapterIndex - 1].id}`,
-                      )
-                    }
-                    onNext={() =>
-                      navigate(
-                        `/learn/${id}/${chapters[selectedChapterIndex + 1].id}`,
-                      )
-                    }
+                    onPrev={() => goToChapter(selectedChapterIndex - 1)}
+                    onNext={() => goToChapter(selectedChapterIndex + 1)}
                     disablePrev={selectedChapterIndex === 0}
                     disableNext={selectedChapterIndex === chapters.length - 1}
                   />

--- a/apps/web/src/pages/LectureLearn.tsx
+++ b/apps/web/src/pages/LectureLearn.tsx
@@ -27,9 +27,15 @@ export const LectureLearn = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   // Hands-free preference: continue voice playback into the next chapter.
-  const [autoAdvance, setAutoAdvance] = useState(
-    () => localStorage.getItem('learnAutoAdvance') === 'true',
-  );
+  // Storage access is guarded — private mode / disabled storage must not crash
+  // the page; the preference simply falls back to session-only in that case.
+  const [autoAdvance, setAutoAdvance] = useState(() => {
+    try {
+      return localStorage.getItem('learnAutoAdvance') === 'true';
+    } catch {
+      return false;
+    }
+  });
   // Set when an auto-advance navigation happens so the next chapter resumes
   // playback once its questions have loaded.
   const [pendingAutoStart, setPendingAutoStart] = useState(false);
@@ -54,7 +60,11 @@ export const LectureLearn = () => {
 
   const handleAutoAdvanceChange = (checked: boolean) => {
     setAutoAdvance(checked);
-    localStorage.setItem('learnAutoAdvance', String(checked));
+    try {
+      localStorage.setItem('learnAutoAdvance', String(checked));
+    } catch {
+      // Storage unavailable — the preference stays in memory for this session.
+    }
   };
 
   // Navigate to a chapter on explicit user intent. Clears any pending
@@ -175,21 +185,40 @@ export const LectureLearn = () => {
 
   // Auto-advance: when a chapter's playback finishes and the preference is on,
   // move to the next chapter and flag it to resume playback automatically.
+  //
+  // The `pendingAutoStart` guard is essential: navigation updates
+  // `selectedChapterIndex` one render before the voice hook resets `status`
+  // away from `'finished'`. Without the guard this effect would re-fire with a
+  // stale `'finished'` status and navigate a second time, skipping a chapter.
   const voiceStatus = voice.status;
   useEffect(() => {
-    if (voiceStatus !== 'finished' || !autoAdvance) return;
+    if (voiceStatus !== 'finished' || !autoAdvance || pendingAutoStart) return;
     const nextIndex = selectedChapterIndex + 1;
     if (nextIndex >= chapters.length) return;
     setPendingAutoStart(true);
     navigate(`/learn/${id}/${chapters[nextIndex].id}`);
-  }, [voiceStatus, autoAdvance, selectedChapterIndex, chapters, id, navigate]);
+  }, [
+    voiceStatus,
+    autoAdvance,
+    pendingAutoStart,
+    selectedChapterIndex,
+    chapters,
+    id,
+    navigate,
+  ]);
 
   // Auto-advance follow-up: once the freshly-navigated chapter has loaded its
   // questions, resume playback. Chapters with no questions are skipped.
   const voiceToggle = voice.toggle;
   const questionsLoading = currentChapterQuestionsQuery.isLoading;
   useEffect(() => {
-    if (!pendingAutoStart || voiceStatus !== 'idle' || questionsLoading) return;
+    if (!pendingAutoStart) return;
+    // The preference was switched off mid-flight — abandon the pending resume.
+    if (!autoAdvance) {
+      setPendingAutoStart(false);
+      return;
+    }
+    if (voiceStatus !== 'idle' || questionsLoading) return;
     if (currentChapterQuestions.length > 0) {
       setPendingAutoStart(false);
       voiceToggle();
@@ -205,6 +234,7 @@ export const LectureLearn = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     pendingAutoStart,
+    autoAdvance,
     voiceStatus,
     questionsLoading,
     currentChapterQuestions,

--- a/apps/web/src/pages/LectureLearn.tsx
+++ b/apps/web/src/pages/LectureLearn.tsx
@@ -186,13 +186,22 @@ export const LectureLearn = () => {
   // Auto-advance: when a chapter's playback finishes and the preference is on,
   // move to the next chapter and flag it to resume playback automatically.
   //
-  // The `pendingAutoStart` guard is essential: navigation updates
-  // `selectedChapterIndex` one render before the voice hook resets `status`
-  // away from `'finished'`. Without the guard this effect would re-fire with a
-  // stale `'finished'` status and navigate a second time, skipping a chapter.
+  // Two guards keep this from over-firing:
+  //  - Edge detection (`prevVoiceStatusRef`): only the *transition* into
+  //    `'finished'` advances. Re-running this effect because another
+  //    dependency changed — e.g. the user flipping the auto-advance toggle
+  //    while a chapter is already finished — must not trigger a navigation.
+  //  - `pendingAutoStart`: navigation updates `selectedChapterIndex` one
+  //    render before the voice hook resets `status` away from `'finished'`,
+  //    so without it this effect could re-fire on a stale `'finished'` and
+  //    navigate a second time, skipping a chapter.
   const voiceStatus = voice.status;
+  const prevVoiceStatusRef = useRef(voiceStatus);
   useEffect(() => {
-    if (voiceStatus !== 'finished' || !autoAdvance || pendingAutoStart) return;
+    const prevVoiceStatus = prevVoiceStatusRef.current;
+    prevVoiceStatusRef.current = voiceStatus;
+    if (voiceStatus !== 'finished' || prevVoiceStatus === 'finished') return;
+    if (!autoAdvance || pendingAutoStart) return;
     const nextIndex = selectedChapterIndex + 1;
     if (nextIndex >= chapters.length) return;
     setPendingAutoStart(true);
@@ -210,11 +219,20 @@ export const LectureLearn = () => {
   // Auto-advance follow-up: once the freshly-navigated chapter has loaded its
   // questions, resume playback. Chapters with no questions are skipped.
   const voiceToggle = voice.toggle;
+  const voiceIsActive = voice.isActive;
   const questionsLoading = currentChapterQuestionsQuery.isLoading;
   useEffect(() => {
     if (!pendingAutoStart) return;
     // The preference was switched off mid-flight — abandon the pending resume.
     if (!autoAdvance) {
+      setPendingAutoStart(false);
+      return;
+    }
+    // Playback became active (or errored) through another path — typically a
+    // manual Play click in the brief window before this effect resumes. Drop
+    // the pending flag so it cannot get stuck `true` and silently disable
+    // auto-advance for the rest of the session.
+    if (voiceIsActive || voiceStatus === 'error') {
       setPendingAutoStart(false);
       return;
     }
@@ -231,11 +249,17 @@ export const LectureLearn = () => {
     } else {
       setPendingAutoStart(false);
     }
+    // `voiceToggle` is deliberately excluded from the deps below: the voice
+    // hook returns a fresh `toggle` identity on every render, so depending on
+    // it would re-run this effect constantly. Its behavior is stable and it is
+    // invoked exactly once per resume (right after `pendingAutoStart` is
+    // cleared), so referencing a slightly stale closure is harmless here.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     pendingAutoStart,
     autoAdvance,
     voiceStatus,
+    voiceIsActive,
     questionsLoading,
     currentChapterQuestions,
     selectedChapterIndex,

--- a/apps/web/tests/lecture-learn.spec.ts
+++ b/apps/web/tests/lecture-learn.spec.ts
@@ -378,6 +378,300 @@ test.describe('Lecture Learn', () => {
     ).toHaveCount(0);
   });
 
+  test('auto-advance preference persists across reloads', async ({ page }) => {
+    const lectureId = 'lecture-1';
+    const lecture = { id: lectureId, title: 'Persist Lecture', description: 'D' };
+    const chapters = [{ id: 'c1', lectureId, order: 0, association: '' }];
+    const firstQuestions = { c1: { question: 'Chapter 1 Intro' } };
+    const c1Questions = [
+      {
+        id: 'q1',
+        chapterId: 'c1',
+        question: 'Chapter 1 Intro',
+        answer: 'Answer 1',
+        order: 0,
+      },
+    ];
+
+    await page.route('**/api/trpc/lectures.getLecture?*', async (route) => {
+      await route.fulfill({ json: { result: { data: lecture } } });
+    });
+    await page.route('**/api/trpc/chapters.getChapters*', async (route) => {
+      await route.fulfill({ json: { result: { data: chapters } } });
+    });
+    await page.route(
+      '**/api/trpc/questions.getFirstQuestionsByLecture*',
+      async (route) => {
+        await route.fulfill({ json: { result: { data: firstQuestions } } });
+      },
+    );
+    await page.route('**/api/trpc/questions.getQuestions?*', async (route) => {
+      await route.fulfill({ json: { result: { data: c1Questions } } });
+    });
+    await page.route('**/api/trpc/speech.isConfigured*', async (route) => {
+      await route.fulfill({ json: { result: { data: true } } });
+    });
+
+    await page.goto(`/#/learn/${lectureId}`);
+
+    const toggle = page.getByRole('checkbox', {
+      name: 'Auto-advance to next chapter',
+    });
+    await expect(toggle).not.toBeChecked();
+    await toggle.check();
+
+    // The preference is written to localStorage.
+    expect(
+      await page.evaluate(() => localStorage.getItem('learnAutoAdvance')),
+    ).toBe('true');
+
+    // After a reload the checkbox restores its state from localStorage.
+    await page.reload();
+    await expect(
+      page.getByRole('checkbox', { name: 'Auto-advance to next chapter' }),
+    ).toBeChecked();
+  });
+
+  test('manual chapter change does not auto-resume when auto-advance is on', async ({
+    page,
+  }) => {
+    const lectureId = 'lecture-1';
+    const lecture = { id: lectureId, title: 'Manual Lecture', description: 'D' };
+    const chapters = [
+      { id: 'c1', lectureId, order: 0, association: '' },
+      { id: 'c2', lectureId, order: 1, association: '' },
+    ];
+    const firstQuestions = {
+      c1: { question: 'Chapter 1 Intro' },
+      c2: { question: 'Chapter 2 Middle' },
+    };
+    const c1Questions = [
+      {
+        id: 'q1',
+        chapterId: 'c1',
+        question: 'Chapter 1 Intro',
+        answer: 'Answer 1',
+        order: 0,
+      },
+    ];
+    const c2Questions = [
+      {
+        id: 'q3',
+        chapterId: 'c2',
+        question: 'Chapter 2 Middle',
+        answer: 'Answer 2',
+        order: 0,
+      },
+    ];
+
+    await page.route('**/api/trpc/lectures.getLecture?*', async (route) => {
+      await route.fulfill({ json: { result: { data: lecture } } });
+    });
+    await page.route('**/api/trpc/chapters.getChapters*', async (route) => {
+      await route.fulfill({ json: { result: { data: chapters } } });
+    });
+    await page.route(
+      '**/api/trpc/questions.getFirstQuestionsByLecture*',
+      async (route) => {
+        await route.fulfill({ json: { result: { data: firstQuestions } } });
+      },
+    );
+    await page.route('**/api/trpc/questions.getQuestions?*', async (route) => {
+      const url = route.request().url();
+      await route.fulfill({
+        json: {
+          result: { data: url.includes('c2') ? c2Questions : c1Questions },
+        },
+      });
+    });
+    await page.route('**/api/trpc/speech.isConfigured*', async (route) => {
+      await route.fulfill({ json: { result: { data: true } } });
+    });
+    // Synthesis hangs so chapter 1 playback stays active and never finishes —
+    // the only chapter change here is the explicit manual one.
+    await page.route('**/api/trpc/speech.synthesize*', async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 10000));
+      await route.fulfill({
+        json: { result: { data: { audioData: '', duration: 0 } } },
+      });
+    });
+
+    await page.goto(`/#/learn/${lectureId}`);
+
+    await page
+      .getByRole('checkbox', { name: 'Auto-advance to next chapter' })
+      .check();
+    await page.getByRole('button', { name: 'Auto-play chapter' }).click();
+    await expect(
+      page.getByRole('button', { name: 'Auto-play chapter' }),
+    ).toHaveCount(0);
+
+    // Manually jump to the next chapter while chapter 1 is still playing.
+    await page.getByRole('button', { name: 'Next' }).click();
+    await expect(page).toHaveURL(new RegExp(`/learn/${lectureId}/c2`));
+
+    // The manual jump must not trigger an auto-resume — chapter 2 stays idle.
+    await expect(
+      page.getByRole('button', { name: 'Auto-play chapter' }),
+    ).toBeVisible();
+    // Give the resume effect a window in which it could wrongly fire.
+    await page.waitForTimeout(1000);
+    await expect(
+      page.getByRole('button', { name: 'Auto-play chapter' }),
+    ).toBeVisible();
+  });
+
+  test('auto-advance stops at the last chapter', async ({ page }) => {
+    const lectureId = 'lecture-1';
+    const lecture = { id: lectureId, title: 'Last Lecture', description: 'D' };
+    const chapters = [
+      { id: 'c1', lectureId, order: 0, association: '' },
+      { id: 'c2', lectureId, order: 1, association: '' },
+    ];
+    const firstQuestions = {
+      c1: { question: 'Chapter 1 Intro' },
+      c2: { question: 'Chapter 2 End' },
+    };
+    const c1Questions = [
+      {
+        id: 'q1',
+        chapterId: 'c1',
+        question: 'Chapter 1 Intro',
+        answer: 'Answer 1',
+        order: 0,
+      },
+    ];
+    const c2Questions = [
+      {
+        id: 'q3',
+        chapterId: 'c2',
+        question: 'Chapter 2 End',
+        answer: 'Answer 2',
+        order: 0,
+      },
+    ];
+
+    await page.route('**/api/trpc/lectures.getLecture?*', async (route) => {
+      await route.fulfill({ json: { result: { data: lecture } } });
+    });
+    await page.route('**/api/trpc/chapters.getChapters*', async (route) => {
+      await route.fulfill({ json: { result: { data: chapters } } });
+    });
+    await page.route(
+      '**/api/trpc/questions.getFirstQuestionsByLecture*',
+      async (route) => {
+        await route.fulfill({ json: { result: { data: firstQuestions } } });
+      },
+    );
+    await page.route('**/api/trpc/questions.getQuestions?*', async (route) => {
+      const url = route.request().url();
+      await route.fulfill({
+        json: {
+          result: { data: url.includes('c2') ? c2Questions : c1Questions },
+        },
+      });
+    });
+    await page.route('**/api/trpc/speech.isConfigured*', async (route) => {
+      await route.fulfill({ json: { result: { data: true } } });
+    });
+    // Synthesis resolves immediately so playback finishes quickly.
+    await page.route('**/api/trpc/speech.synthesize*', async (route) => {
+      await route.fulfill({
+        json: { result: { data: { audioData: '', duration: 0 } } },
+      });
+    });
+
+    // Start directly on the last chapter.
+    await page.goto(`/#/learn/${lectureId}/c2`);
+
+    await page
+      .getByRole('checkbox', { name: 'Auto-advance to next chapter' })
+      .check();
+    await page.getByRole('button', { name: 'Auto-play chapter' }).click();
+
+    // Playback finishes; with no next chapter the control returns to idle
+    // and the URL stays on the last chapter.
+    await expect(
+      page.getByRole('button', { name: 'Auto-play chapter' }),
+    ).toBeVisible({ timeout: 15000 });
+    await page.waitForTimeout(500);
+    await expect(page).toHaveURL(new RegExp(`/learn/${lectureId}/c2`));
+  });
+
+  test('playback stops at chapter end when auto-advance is off', async ({
+    page,
+  }) => {
+    const lectureId = 'lecture-1';
+    const lecture = { id: lectureId, title: 'Stay Lecture', description: 'D' };
+    const chapters = [
+      { id: 'c1', lectureId, order: 0, association: '' },
+      { id: 'c2', lectureId, order: 1, association: '' },
+    ];
+    const firstQuestions = {
+      c1: { question: 'Chapter 1 Intro' },
+      c2: { question: 'Chapter 2 Middle' },
+    };
+    const c1Questions = [
+      {
+        id: 'q1',
+        chapterId: 'c1',
+        question: 'Chapter 1 Intro',
+        answer: 'Answer 1',
+        order: 0,
+      },
+    ];
+    const c2Questions = [
+      {
+        id: 'q3',
+        chapterId: 'c2',
+        question: 'Chapter 2 Middle',
+        answer: 'Answer 2',
+        order: 0,
+      },
+    ];
+
+    await page.route('**/api/trpc/lectures.getLecture?*', async (route) => {
+      await route.fulfill({ json: { result: { data: lecture } } });
+    });
+    await page.route('**/api/trpc/chapters.getChapters*', async (route) => {
+      await route.fulfill({ json: { result: { data: chapters } } });
+    });
+    await page.route(
+      '**/api/trpc/questions.getFirstQuestionsByLecture*',
+      async (route) => {
+        await route.fulfill({ json: { result: { data: firstQuestions } } });
+      },
+    );
+    await page.route('**/api/trpc/questions.getQuestions?*', async (route) => {
+      const url = route.request().url();
+      await route.fulfill({
+        json: {
+          result: { data: url.includes('c2') ? c2Questions : c1Questions },
+        },
+      });
+    });
+    await page.route('**/api/trpc/speech.isConfigured*', async (route) => {
+      await route.fulfill({ json: { result: { data: true } } });
+    });
+    await page.route('**/api/trpc/speech.synthesize*', async (route) => {
+      await route.fulfill({
+        json: { result: { data: { audioData: '', duration: 0 } } },
+      });
+    });
+
+    await page.goto(`/#/learn/${lectureId}/c1`);
+
+    // Auto-advance is left at its default (off); just start playback.
+    await page.getByRole('button', { name: 'Auto-play chapter' }).click();
+
+    // Playback finishes; without auto-advance the app stays on chapter 1.
+    await expect(
+      page.getByRole('button', { name: 'Auto-play chapter' }),
+    ).toBeVisible({ timeout: 15000 });
+    await page.waitForTimeout(500);
+    await expect(page).toHaveURL(new RegExp(`/learn/${lectureId}/c1`));
+  });
+
   test('search functionality', async ({ page }) => {
     const lectureId = 'lecture-1';
     const lecture = {

--- a/apps/web/tests/lecture-learn.spec.ts
+++ b/apps/web/tests/lecture-learn.spec.ts
@@ -785,6 +785,90 @@ test.describe('Lecture Learn', () => {
     expect([...synthesizedChapters].sort()).toEqual(['c1', 'c2', 'c3']);
   });
 
+  test('enabling auto-advance after a chapter finished does not jump', async ({
+    page,
+  }) => {
+    const lectureId = 'lecture-1';
+    const lecture = {
+      id: lectureId,
+      title: 'Toggle Lecture',
+      description: 'D',
+    };
+    const chapters = [
+      { id: 'c1', lectureId, order: 0, association: '' },
+      { id: 'c2', lectureId, order: 1, association: '' },
+    ];
+    const firstQuestions = {
+      c1: { question: 'Chapter 1 Intro' },
+      c2: { question: 'Chapter 2 Middle' },
+    };
+    const c1Questions = [
+      {
+        id: 'q1',
+        chapterId: 'c1',
+        question: 'Chapter 1 Intro',
+        answer: 'Answer 1',
+        order: 0,
+      },
+    ];
+    const c2Questions = [
+      {
+        id: 'q3',
+        chapterId: 'c2',
+        question: 'Chapter 2 Middle',
+        answer: 'Answer 2',
+        order: 0,
+      },
+    ];
+
+    await page.route('**/api/trpc/lectures.getLecture?*', async (route) => {
+      await route.fulfill({ json: { result: { data: lecture } } });
+    });
+    await page.route('**/api/trpc/chapters.getChapters*', async (route) => {
+      await route.fulfill({ json: { result: { data: chapters } } });
+    });
+    await page.route(
+      '**/api/trpc/questions.getFirstQuestionsByLecture*',
+      async (route) => {
+        await route.fulfill({ json: { result: { data: firstQuestions } } });
+      },
+    );
+    await page.route('**/api/trpc/questions.getQuestions?*', async (route) => {
+      const url = route.request().url();
+      await route.fulfill({
+        json: {
+          result: { data: url.includes('c2') ? c2Questions : c1Questions },
+        },
+      });
+    });
+    await page.route('**/api/trpc/speech.isConfigured*', async (route) => {
+      await route.fulfill({ json: { result: { data: true } } });
+    });
+    // Synthesis resolves immediately so chapter 1 playback finishes quickly.
+    await page.route('**/api/trpc/speech.synthesize*', async (route) => {
+      await route.fulfill({
+        json: { result: { data: { audioData: '', duration: 0 } } },
+      });
+    });
+
+    await page.goto(`/#/learn/${lectureId}/c1`);
+
+    // Auto-advance left at its default (off); play chapter 1 to completion.
+    await page.getByRole('button', { name: 'Auto-play chapter' }).click();
+    await expect(
+      page.getByRole('button', { name: 'Auto-play chapter' }),
+    ).toBeVisible({ timeout: 15000 });
+    await expect(page).toHaveURL(new RegExp(`/learn/${lectureId}/c1`));
+
+    // Enabling the preference now must not retroactively trigger a jump —
+    // only a fresh chapter completion may advance.
+    await page
+      .getByRole('checkbox', { name: 'Auto-advance to next chapter' })
+      .check();
+    await page.waitForTimeout(500);
+    await expect(page).toHaveURL(new RegExp(`/learn/${lectureId}/c1`));
+  });
+
   test('search functionality', async ({ page }) => {
     const lectureId = 'lecture-1';
     const lecture = {

--- a/apps/web/tests/lecture-learn.spec.ts
+++ b/apps/web/tests/lecture-learn.spec.ts
@@ -214,6 +214,170 @@ test.describe('Lecture Learn', () => {
     ).toBeVisible();
   });
 
+  test('auto-advance resumes voice playback in the next chapter', async ({
+    page,
+  }) => {
+    const lectureId = 'lecture-1';
+    const lecture = { id: lectureId, title: 'Auto Lecture', description: 'D' };
+    const chapters = [
+      { id: 'c1', lectureId, order: 0, association: '' },
+      { id: 'c2', lectureId, order: 1, association: '' },
+    ];
+    const firstQuestions = {
+      c1: { question: 'Chapter 1 Intro' },
+      c2: { question: 'Chapter 2 Middle' },
+    };
+    const c1Questions = [
+      {
+        id: 'q1',
+        chapterId: 'c1',
+        question: 'Chapter 1 Intro',
+        answer: 'Answer 1',
+        order: 0,
+      },
+    ];
+    const c2Questions = [
+      {
+        id: 'q3',
+        chapterId: 'c2',
+        question: 'Chapter 2 Middle',
+        answer: 'Answer 2',
+        order: 0,
+      },
+    ];
+
+    await page.route('**/api/trpc/lectures.getLecture?*', async (route) => {
+      await route.fulfill({ json: { result: { data: lecture } } });
+    });
+    await page.route('**/api/trpc/chapters.getChapters*', async (route) => {
+      await route.fulfill({ json: { result: { data: chapters } } });
+    });
+    await page.route(
+      '**/api/trpc/questions.getFirstQuestionsByLecture*',
+      async (route) => {
+        await route.fulfill({ json: { result: { data: firstQuestions } } });
+      },
+    );
+    await page.route('**/api/trpc/questions.getQuestions?*', async (route) => {
+      const url = route.request().url();
+      await route.fulfill({
+        json: {
+          result: { data: url.includes('c2') ? c2Questions : c1Questions },
+        },
+      });
+    });
+    await page.route('**/api/trpc/speech.isConfigured*', async (route) => {
+      await route.fulfill({ json: { result: { data: true } } });
+    });
+    // Chapter 1 synthesis resolves immediately so its playback finishes fast;
+    // chapter 2 synthesis hangs so the resumed playback stays visibly active.
+    await page.route('**/api/trpc/speech.synthesize*', async (route) => {
+      const body = route.request().postData() || '';
+      if (body.includes('Chapter 2') || body.includes('Answer 2')) {
+        await new Promise((resolve) => setTimeout(resolve, 10000));
+      }
+      await route.fulfill({
+        json: { result: { data: { audioData: '', duration: 0 } } },
+      });
+    });
+
+    await page.goto(`/#/learn/${lectureId}`);
+
+    // Enable auto-advance, then start playback on chapter 1.
+    await page
+      .getByRole('checkbox', { name: 'Auto-advance to next chapter' })
+      .check();
+    await page.getByRole('button', { name: 'Auto-play chapter' }).click();
+
+    // Chapter 1 finishes -> app advances to chapter 2 and resumes playback.
+    await expect(page).toHaveURL(new RegExp(`/learn/${lectureId}/c2`), {
+      timeout: 15000,
+    });
+    await expect(
+      page.getByRole('button', { name: 'Auto-play chapter' }),
+    ).toHaveCount(0);
+  });
+
+  test('auto-advance skips chapters with no questions', async ({ page }) => {
+    const lectureId = 'lecture-1';
+    const lecture = { id: lectureId, title: 'Skip Lecture', description: 'D' };
+    const chapters = [
+      { id: 'c1', lectureId, order: 0, association: '' },
+      { id: 'c2', lectureId, order: 1, association: '' },
+      { id: 'c3', lectureId, order: 2, association: '' },
+    ];
+    const firstQuestions = {
+      c1: { question: 'Chapter 1 Intro' },
+      c2: { question: 'Empty Chapter' },
+      c3: { question: 'Chapter 3 End' },
+    };
+    const c1Questions = [
+      {
+        id: 'q1',
+        chapterId: 'c1',
+        question: 'Chapter 1 Intro',
+        answer: 'Answer 1',
+        order: 0,
+      },
+    ];
+    const c3Questions = [
+      {
+        id: 'q3',
+        chapterId: 'c3',
+        question: 'Chapter 3 End',
+        answer: 'Answer 3',
+        order: 0,
+      },
+    ];
+
+    await page.route('**/api/trpc/lectures.getLecture?*', async (route) => {
+      await route.fulfill({ json: { result: { data: lecture } } });
+    });
+    await page.route('**/api/trpc/chapters.getChapters*', async (route) => {
+      await route.fulfill({ json: { result: { data: chapters } } });
+    });
+    await page.route(
+      '**/api/trpc/questions.getFirstQuestionsByLecture*',
+      async (route) => {
+        await route.fulfill({ json: { result: { data: firstQuestions } } });
+      },
+    );
+    await page.route('**/api/trpc/questions.getQuestions?*', async (route) => {
+      const url = route.request().url();
+      let data = c1Questions;
+      if (url.includes('c2')) data = [];
+      else if (url.includes('c3')) data = c3Questions;
+      await route.fulfill({ json: { result: { data } } });
+    });
+    await page.route('**/api/trpc/speech.isConfigured*', async (route) => {
+      await route.fulfill({ json: { result: { data: true } } });
+    });
+    await page.route('**/api/trpc/speech.synthesize*', async (route) => {
+      const body = route.request().postData() || '';
+      if (body.includes('Chapter 3') || body.includes('Answer 3')) {
+        await new Promise((resolve) => setTimeout(resolve, 10000));
+      }
+      await route.fulfill({
+        json: { result: { data: { audioData: '', duration: 0 } } },
+      });
+    });
+
+    await page.goto(`/#/learn/${lectureId}`);
+
+    await page
+      .getByRole('checkbox', { name: 'Auto-advance to next chapter' })
+      .check();
+    await page.getByRole('button', { name: 'Auto-play chapter' }).click();
+
+    // Chapter 1 finishes -> empty chapter 2 is skipped -> chapter 3 plays.
+    await expect(page).toHaveURL(new RegExp(`/learn/${lectureId}/c3`), {
+      timeout: 15000,
+    });
+    await expect(
+      page.getByRole('button', { name: 'Auto-play chapter' }),
+    ).toHaveCount(0);
+  });
+
   test('search functionality', async ({ page }) => {
     const lectureId = 'lecture-1';
     const lecture = {

--- a/apps/web/tests/lecture-learn.spec.ts
+++ b/apps/web/tests/lecture-learn.spec.ts
@@ -380,7 +380,11 @@ test.describe('Lecture Learn', () => {
 
   test('auto-advance preference persists across reloads', async ({ page }) => {
     const lectureId = 'lecture-1';
-    const lecture = { id: lectureId, title: 'Persist Lecture', description: 'D' };
+    const lecture = {
+      id: lectureId,
+      title: 'Persist Lecture',
+      description: 'D',
+    };
     const chapters = [{ id: 'c1', lectureId, order: 0, association: '' }];
     const firstQuestions = { c1: { question: 'Chapter 1 Intro' } };
     const c1Questions = [
@@ -436,7 +440,11 @@ test.describe('Lecture Learn', () => {
     page,
   }) => {
     const lectureId = 'lecture-1';
-    const lecture = { id: lectureId, title: 'Manual Lecture', description: 'D' };
+    const lecture = {
+      id: lectureId,
+      title: 'Manual Lecture',
+      description: 'D',
+    };
     const chapters = [
       { id: 'c1', lectureId, order: 0, association: '' },
       { id: 'c2', lectureId, order: 1, association: '' },
@@ -670,6 +678,111 @@ test.describe('Lecture Learn', () => {
     ).toBeVisible({ timeout: 15000 });
     await page.waitForTimeout(500);
     await expect(page).toHaveURL(new RegExp(`/learn/${lectureId}/c1`));
+  });
+
+  test('auto-advance plays every chapter across three non-empty chapters', async ({
+    page,
+  }) => {
+    const lectureId = 'lecture-1';
+    const lecture = { id: lectureId, title: 'Chain Lecture', description: 'D' };
+    const chapters = [
+      { id: 'c1', lectureId, order: 0, association: '' },
+      { id: 'c2', lectureId, order: 1, association: '' },
+      { id: 'c3', lectureId, order: 2, association: '' },
+    ];
+    const firstQuestions = {
+      c1: { question: 'Chapter 1 Intro' },
+      c2: { question: 'Chapter 2 Middle' },
+      c3: { question: 'Chapter 3 End' },
+    };
+    const c1Questions = [
+      {
+        id: 'q1',
+        chapterId: 'c1',
+        question: 'Chapter 1 Intro',
+        answer: 'Answer 1',
+        order: 0,
+      },
+    ];
+    const c2Questions = [
+      {
+        id: 'q2',
+        chapterId: 'c2',
+        question: 'Chapter 2 Middle',
+        answer: 'Answer 2',
+        order: 0,
+      },
+    ];
+    const c3Questions = [
+      {
+        id: 'q3',
+        chapterId: 'c3',
+        question: 'Chapter 3 End',
+        answer: 'Answer 3',
+        order: 0,
+      },
+    ];
+
+    await page.route('**/api/trpc/lectures.getLecture?*', async (route) => {
+      await route.fulfill({ json: { result: { data: lecture } } });
+    });
+    await page.route('**/api/trpc/chapters.getChapters*', async (route) => {
+      await route.fulfill({ json: { result: { data: chapters } } });
+    });
+    await page.route(
+      '**/api/trpc/questions.getFirstQuestionsByLecture*',
+      async (route) => {
+        await route.fulfill({ json: { result: { data: firstQuestions } } });
+      },
+    );
+    await page.route('**/api/trpc/questions.getQuestions?*', async (route) => {
+      const url = route.request().url();
+      let data = c1Questions;
+      if (url.includes('c2')) data = c2Questions;
+      else if (url.includes('c3')) data = c3Questions;
+      await route.fulfill({ json: { result: { data } } });
+    });
+    await page.route('**/api/trpc/speech.isConfigured*', async (route) => {
+      await route.fulfill({ json: { result: { data: true } } });
+    });
+    // Record every synthesised chapter so we can prove no chapter was skipped.
+    // Chapters 1 and 2 resolve immediately; chapter 3 hangs so playback stays
+    // visibly active once the chain reaches the last chapter.
+    const synthesizedChapters = new Set<string>();
+    await page.route('**/api/trpc/speech.synthesize*', async (route) => {
+      const body = route.request().postData() || '';
+      if (body.includes('Chapter 1') || body.includes('Answer 1')) {
+        synthesizedChapters.add('c1');
+      }
+      if (body.includes('Chapter 2') || body.includes('Answer 2')) {
+        synthesizedChapters.add('c2');
+      }
+      if (body.includes('Chapter 3') || body.includes('Answer 3')) {
+        synthesizedChapters.add('c3');
+        await new Promise((resolve) => setTimeout(resolve, 10000));
+      }
+      await route.fulfill({
+        json: { result: { data: { audioData: '', duration: 0 } } },
+      });
+    });
+
+    await page.goto(`/#/learn/${lectureId}`);
+
+    await page
+      .getByRole('checkbox', { name: 'Auto-advance to next chapter' })
+      .check();
+    await page.getByRole('button', { name: 'Auto-play chapter' }).click();
+
+    // The chain advances c1 -> c2 -> c3, playing each chapter in turn.
+    await expect(page).toHaveURL(new RegExp(`/learn/${lectureId}/c3`), {
+      timeout: 15000,
+    });
+    await expect(
+      page.getByRole('button', { name: 'Auto-play chapter' }),
+    ).toHaveCount(0);
+
+    // The middle chapter must not be skipped — all three were synthesised.
+    expect([...synthesizedChapters].sort()).toEqual(['c1', 'c2', 'c3']);
   });
 
   test('search functionality', async ({ page }) => {


### PR DESCRIPTION
## Summary

Learn mode's hands-free voice feature reads a chapter's question/answer cards aloud but deliberately stops at the **end of the chapter** — the user has to advance manually to keep listening.

This PR adds an **"Auto-advance" toggle** (default **off**) to the Learn-mode chapter header. When enabled, voice playback continues into the next chapter automatically once the current one finishes — a continuous, hands-free experience across the whole lecture.

## Behaviour

- **Default off** — finishing a chapter stops playback, exactly as before.
- **Enabled** — when a chapter's playback finishes, the app navigates to the next chapter and resumes reading automatically.
- Chapters with **no questions are skipped** until one with content is found, or the lecture ends.
- The preference is **persisted in `localStorage`** (`learnAutoAdvance`).
- Manual navigation (Next/Prev buttons, arrow keys, sidebar) clears any pending auto-start, so a manual jump never triggers a surprise resume.
- Toggling auto-advance **on after a chapter has already finished** does **not** retroactively jump — only a fresh chapter completion advances.

## Implementation

- New `AutoAdvanceToggle` component, rendered as a **compact icon pill** (`ChevronsRight`) that expands to reveal its label on hover/keyboard focus, keeping the chapter header uncluttered. A visually-hidden checkbox preserves accessibility and persistence semantics.
- The `VoicePlaybackButton` ("Play" control) was given the **same compact icon-pill model** for a consistent toolbar — icon-only by default, label expanding on hover/focus; the error state stays expanded so its retry hint remains visible.
- `LectureLearn.tsx`: `autoAdvance` preference state, a `pendingAutoStart` flag, and two effects — one advances on `status === 'finished'`, the other resumes (or skips empty chapters) once the next chapter's questions load. A `goToChapter()` helper centralises manual navigation.
- `useChapterVoicePlayback.ts` is **unchanged** — its existing `'finished'` status and chapter-change reset already provide everything needed.
- New `speech.autoAdvance` / `speech.autoAdvanceShort` i18n keys (en + de).

## Review hardening

A code review surfaced two over-firing edges, both now fixed:

- **Stale-finish jump** — the advance effect keyed off the `'finished'` status directly, so flipping the toggle on while a chapter was already finished triggered an unexpected navigation. It now acts only on the *transition* into `'finished'` via a status ref.
- **Stuck `pendingAutoStart` flag** — if playback started through another path (e.g. a manual Play click) during the resume window, the flag could leak `true` forever and silently disable auto-advance for the session. The resume effect now clears the flag when playback is already active or has errored.
- The intentional omission of `voiceToggle` from the resume effect's dependency array is now documented inline.

## Testing

- `tsc --noEmit` — clean
- `eslint` — clean
- Unit tests — 115 passed (incl. `AutoAdvanceToggle.test.tsx`)
- E2E `lecture-learn` (11) + `voice-language` (4) — all passed, incl. auto-advance resume / empty-chapter-skip / persistence / boundary cases / toggle-after-finish-does-not-jump

🤖 Generated with [Claude Code](https://claude.com/claude-code)
