### PR TITLE
refactor(learn): align voice controls with shared IconButton style

### DIFF
--- a/apps/web/src/components/AutoAdvanceToggle.test.tsx
+++ b/apps/web/src/components/AutoAdvanceToggle.test.tsx
@@ -11,27 +11,34 @@ vi.mock('react-i18next', () => ({
 }));
 
 describe('AutoAdvanceToggle', () => {
-  it('renders the label', () => {
+  it('renders an accessibly labeled toggle', () => {
     render(<AutoAdvanceToggle checked={false} onChange={() => {}} />);
-    expect(screen.getByText('speech.autoAdvanceShort')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'speech.autoAdvance' }),
+    ).toBeInTheDocument();
   });
 
-  it('reflects the checked prop', () => {
-    render(<AutoAdvanceToggle checked={true} onChange={() => {}} />);
-    expect(screen.getByRole('checkbox')).toBeChecked();
+  it('reflects the checked prop via aria-pressed', () => {
+    const { rerender } = render(
+      <AutoAdvanceToggle checked={true} onChange={() => {}} />,
+    );
+    expect(screen.getByRole('button')).toHaveAttribute('aria-pressed', 'true');
+
+    rerender(<AutoAdvanceToggle checked={false} onChange={() => {}} />);
+    expect(screen.getByRole('button')).toHaveAttribute('aria-pressed', 'false');
   });
 
   it('fires onChange with the toggled value when clicked', () => {
     const onChange = vi.fn();
     render(<AutoAdvanceToggle checked={false} onChange={onChange} />);
-    fireEvent.click(screen.getByRole('checkbox'));
+    fireEvent.click(screen.getByRole('button'));
     expect(onChange).toHaveBeenCalledWith(true);
   });
 
   it('fires onChange with false when unticked', () => {
     const onChange = vi.fn();
     render(<AutoAdvanceToggle checked={true} onChange={onChange} />);
-    fireEvent.click(screen.getByRole('checkbox'));
+    fireEvent.click(screen.getByRole('button'));
     expect(onChange).toHaveBeenCalledWith(false);
   });
 });

--- a/apps/web/src/components/AutoAdvanceToggle.tsx
+++ b/apps/web/src/components/AutoAdvanceToggle.tsx
@@ -1,47 +1,36 @@
 import { ChevronsRight } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
+import { IconButton } from './buttons/IconButton';
+
 interface AutoAdvanceToggleProps {
   checked: boolean;
   onChange: (checked: boolean) => void;
 }
 
 /**
- * Compact icon toggle controlling whether voice playback in Learn mode continues
- * into the next chapter automatically once the current chapter finishes. Renders
- * icon-only by default and expands to reveal its label on hover or keyboard
- * focus. The preference is persisted by the parent — this component is purely
- * presentational.
+ * Toggle controlling whether voice playback in Learn mode continues into the
+ * next chapter automatically once the current chapter finishes. Renders as a
+ * circular icon button consistent with the other header controls; the enabled
+ * state is conveyed via `aria-pressed` and a primary tint. The preference is
+ * persisted by the parent — this component is purely presentational.
  */
 export const AutoAdvanceToggle = ({
   checked,
   onChange,
 }: AutoAdvanceToggleProps) => {
   const { t } = useTranslation();
-  const fullLabel = t('speech.autoAdvance');
-  const shortLabel = t('speech.autoAdvanceShort');
+  const label = t('speech.autoAdvance');
 
   return (
-    <label
-      className={`group relative flex items-center px-3 py-1.5 text-sm font-medium rounded-full cursor-pointer transition-all
-        ${
-          checked
-            ? 'bg-primary-100 text-primary-700'
-            : 'bg-surface text-on-surface-variant hover:bg-primary-50'
-        }`}
-      title={fullLabel}
-    >
-      <input
-        type="checkbox"
-        checked={checked}
-        onChange={(event) => onChange(event.target.checked)}
-        aria-label={fullLabel}
-        className="peer absolute inset-0 h-full w-full cursor-pointer opacity-0"
-      />
-      <ChevronsRight size={18} aria-hidden="true" />
-      <span className="max-w-0 overflow-hidden whitespace-nowrap opacity-0 transition-all group-hover:ml-2 group-hover:max-w-[12rem] group-hover:opacity-100 peer-focus-visible:ml-2 peer-focus-visible:max-w-[12rem] peer-focus-visible:opacity-100">
-        {shortLabel}
-      </span>
-    </label>
+    <IconButton
+      icon={ChevronsRight}
+      onClick={() => onChange(!checked)}
+      aria-label={label}
+      title={label}
+      aria-pressed={checked}
+      className={checked ? '!bg-primary-100' : ''}
+      iconClassName={checked ? 'text-primary-700' : ''}
+    />
   );
 };

--- a/apps/web/src/components/AutoAdvanceToggle.tsx
+++ b/apps/web/src/components/AutoAdvanceToggle.tsx
@@ -30,7 +30,7 @@ export const AutoAdvanceToggle = ({
       title={label}
       aria-pressed={checked}
       className={checked ? '!bg-primary-100' : ''}
-      iconClassName={checked ? 'text-primary-700' : ''}
+      iconClassName={checked ? '!text-primary-700' : ''}
     />
   );
 };

--- a/apps/web/src/components/VoicePlaybackButton.test.tsx
+++ b/apps/web/src/components/VoicePlaybackButton.test.tsx
@@ -20,7 +20,9 @@ describe('VoicePlaybackButton', () => {
         onToggle={() => {}}
       />,
     );
-    expect(screen.getByRole('button')).toHaveTextContent('speech.autoPlay');
+    expect(
+      screen.getByRole('button', { name: 'speech.autoPlay' }),
+    ).toBeInTheDocument();
   });
 
   it('shows the pause label while actively speaking', () => {
@@ -32,9 +34,9 @@ describe('VoicePlaybackButton', () => {
         onToggle={() => {}}
       />,
     );
-    expect(screen.getByRole('button')).toHaveTextContent(
-      'speech.autoPlayPause',
-    );
+    expect(
+      screen.getByRole('button', { name: 'speech.autoPlayPause' }),
+    ).toBeInTheDocument();
   });
 
   it('shows the resume label while paused', () => {
@@ -46,9 +48,9 @@ describe('VoicePlaybackButton', () => {
         onToggle={() => {}}
       />,
     );
-    expect(screen.getByRole('button')).toHaveTextContent(
-      'speech.autoPlayResume',
-    );
+    expect(
+      screen.getByRole('button', { name: 'speech.autoPlayResume' }),
+    ).toBeInTheDocument();
   });
 
   it('shows the error label when playback has failed', () => {
@@ -60,9 +62,9 @@ describe('VoicePlaybackButton', () => {
         onToggle={() => {}}
       />,
     );
-    expect(screen.getByRole('button')).toHaveTextContent(
-      'speech.autoPlayError',
-    );
+    expect(
+      screen.getByRole('button', { name: 'speech.autoPlayError' }),
+    ).toBeInTheDocument();
   });
 
   it('calls onToggle when clicked', () => {

--- a/apps/web/src/components/VoicePlaybackButton.tsx
+++ b/apps/web/src/components/VoicePlaybackButton.tsx
@@ -2,6 +2,7 @@ import { AlertCircle, Loader2, Pause, Play } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import type { VoicePlaybackStatus } from '../hooks/useChapterVoicePlayback';
+import { IconButton } from './buttons/IconButton';
 
 interface VoicePlaybackButtonProps {
   status: VoicePlaybackStatus;
@@ -11,9 +12,11 @@ interface VoicePlaybackButtonProps {
 }
 
 /**
- * Labeled Play/Pause control that drives the hands-free chapter walkthrough in
- * Learn mode. Rendering is gated by the parent — it is only mounted when the
- * speech service is configured.
+ * Play/Pause control that drives the hands-free chapter walkthrough in Learn
+ * mode. Renders as a circular icon button consistent with the other header
+ * controls; the descriptive label is exposed via `aria-label`/`title`.
+ * Rendering is gated by the parent — it is only mounted when the speech
+ * service is configured.
  */
 export const VoicePlaybackButton = ({
   status,
@@ -37,41 +40,31 @@ export const VoicePlaybackButton = ({
           ? t('speech.autoPlayLoading')
           : t('speech.autoPlayPause');
 
-  const icon = isError ? (
-    <AlertCircle size={18} />
-  ) : isLoading ? (
-    <Loader2 size={18} className="animate-spin" />
-  ) : showPause ? (
-    <Pause size={18} />
-  ) : (
-    <Play size={18} />
-  );
+  const icon = isError
+    ? AlertCircle
+    : isLoading
+      ? Loader2
+      : showPause
+        ? Pause
+        : Play;
 
   return (
-    <button
-      type="button"
+    <IconButton
+      icon={icon}
       onClick={onToggle}
-      className={`group relative flex items-center px-3 py-1.5 text-sm font-medium rounded-full transition-all
-        ${
-          isError
-            ? 'bg-red-50 text-red-700 hover:bg-red-100'
-            : showPause
-              ? 'bg-primary-100 text-primary-700'
-              : 'bg-surface text-on-surface-variant hover:bg-primary-50'
-        }`}
       aria-label={label}
       title={label}
-    >
-      {icon}
-      <span
-        className={`overflow-hidden whitespace-nowrap transition-all ${
-          isError
-            ? 'ml-2 max-w-[20rem] opacity-100'
-            : 'max-w-0 opacity-0 group-hover:ml-2 group-hover:max-w-[12rem] group-hover:opacity-100 group-focus-visible:ml-2 group-focus-visible:max-w-[12rem] group-focus-visible:opacity-100'
-        }`}
-      >
-        {label}
-      </span>
-    </button>
+      variant={isError ? 'danger' : 'primary'}
+      className={isError ? '!bg-red-50' : showPause ? '!bg-primary-100' : ''}
+      iconClassName={
+        isLoading
+          ? 'animate-spin'
+          : isError
+            ? 'text-red-600'
+            : showPause
+              ? 'text-primary-700'
+              : ''
+      }
+    />
   );
 };

--- a/apps/web/src/components/VoicePlaybackButton.tsx
+++ b/apps/web/src/components/VoicePlaybackButton.tsx
@@ -14,9 +14,10 @@ interface VoicePlaybackButtonProps {
 /**
  * Play/Pause control that drives the hands-free chapter walkthrough in Learn
  * mode. Renders as a circular icon button consistent with the other header
- * controls; the descriptive label is exposed via `aria-label`/`title`.
- * Rendering is gated by the parent — it is only mounted when the speech
- * service is configured.
+ * controls; the descriptive label is exposed via `aria-label`/`title`. The
+ * error state additionally renders the label as visible text, since a failure
+ * should be noticeable without hovering. Rendering is gated by the parent — it
+ * is only mounted when the speech service is configured.
  */
 export const VoicePlaybackButton = ({
   status,
@@ -40,13 +41,24 @@ export const VoicePlaybackButton = ({
           ? t('speech.autoPlayLoading')
           : t('speech.autoPlayPause');
 
-  const icon = isError
-    ? AlertCircle
-    : isLoading
-      ? Loader2
-      : showPause
-        ? Pause
-        : Play;
+  if (isError) {
+    return (
+      <div className="flex items-center gap-2">
+        <IconButton
+          icon={AlertCircle}
+          onClick={onToggle}
+          aria-label={label}
+          title={label}
+          variant="danger"
+          className="!bg-red-50"
+          iconClassName="!text-red-600"
+        />
+        <span className="text-sm font-medium text-red-700">{label}</span>
+      </div>
+    );
+  }
+
+  const icon = isLoading ? Loader2 : showPause ? Pause : Play;
 
   return (
     <IconButton
@@ -54,16 +66,10 @@ export const VoicePlaybackButton = ({
       onClick={onToggle}
       aria-label={label}
       title={label}
-      variant={isError ? 'danger' : 'primary'}
-      className={isError ? '!bg-red-50' : showPause ? '!bg-primary-100' : ''}
+      aria-pressed={showPause}
+      className={showPause ? '!bg-primary-100' : ''}
       iconClassName={
-        isLoading
-          ? 'animate-spin'
-          : isError
-            ? 'text-red-600'
-            : showPause
-              ? 'text-primary-700'
-              : ''
+        isLoading ? 'animate-spin' : showPause ? '!text-primary-700' : ''
       }
     />
   );

--- a/apps/web/src/components/buttons/IconButton.tsx
+++ b/apps/web/src/components/buttons/IconButton.tsx
@@ -20,6 +20,8 @@ export interface IconButtonProps extends Omit<
   variant?: IconButtonVariant;
   /** Size variant */
   size?: 'sm' | 'md';
+  /** Additional CSS classes for the icon itself (e.g. spin animation, color) */
+  iconClassName?: string;
 }
 
 // Icon button specific styling
@@ -51,6 +53,7 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
       variant = 'primary',
       size = 'md',
       className = '',
+      iconClassName = '',
       ...props
     },
     ref,
@@ -74,7 +77,9 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
         className={iconButtonClasses}
         {...props}
       >
-        <Icon className={`${iconSizeClasses[size]} text-gray-600`} />
+        <Icon
+          className={`${iconSizeClasses[size]} text-gray-600 ${iconClassName}`.trim()}
+        />
       </Button>
     );
   },

--- a/apps/web/tests/lecture-learn.spec.ts
+++ b/apps/web/tests/lecture-learn.spec.ts
@@ -102,7 +102,7 @@ test.describe('Lecture Learn', () => {
     await expect(page.getByText('Answer Detail 1')).toBeVisible();
 
     // Test Navigation: Next Button
-    const nextButton = page.getByRole('button', { name: 'Next' });
+    const nextButton = page.getByRole('button', { name: 'Next', exact: true });
     await expect(nextButton).toBeVisible();
     await nextButton.click();
 
@@ -207,7 +207,7 @@ test.describe('Lecture Learn', () => {
     await expect(playButton).toHaveCount(0);
 
     // Changing chapter aborts playback; the control resets to its play state.
-    await page.getByRole('button', { name: 'Next' }).click();
+    await page.getByRole('button', { name: 'Next', exact: true }).click();
     await expect(page).toHaveURL(new RegExp(`/learn/${lectureId}/c2`));
     await expect(
       page.getByRole('button', { name: 'Auto-play chapter' }),
@@ -285,8 +285,8 @@ test.describe('Lecture Learn', () => {
 
     // Enable auto-advance, then start playback on chapter 1.
     await page
-      .getByRole('checkbox', { name: 'Auto-advance to next chapter' })
-      .check();
+      .getByRole('button', { name: 'Auto-advance to next chapter' })
+      .click();
     await page.getByRole('button', { name: 'Auto-play chapter' }).click();
 
     // Chapter 1 finishes -> app advances to chapter 2 and resumes playback.
@@ -365,8 +365,8 @@ test.describe('Lecture Learn', () => {
     await page.goto(`/#/learn/${lectureId}`);
 
     await page
-      .getByRole('checkbox', { name: 'Auto-advance to next chapter' })
-      .check();
+      .getByRole('button', { name: 'Auto-advance to next chapter' })
+      .click();
     await page.getByRole('button', { name: 'Auto-play chapter' }).click();
 
     // Chapter 1 finishes -> empty chapter 2 is skipped -> chapter 3 plays.
@@ -418,22 +418,22 @@ test.describe('Lecture Learn', () => {
 
     await page.goto(`/#/learn/${lectureId}`);
 
-    const toggle = page.getByRole('checkbox', {
+    const toggle = page.getByRole('button', {
       name: 'Auto-advance to next chapter',
     });
-    await expect(toggle).not.toBeChecked();
-    await toggle.check();
+    await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+    await toggle.click();
 
     // The preference is written to localStorage.
     expect(
       await page.evaluate(() => localStorage.getItem('learnAutoAdvance')),
     ).toBe('true');
 
-    // After a reload the checkbox restores its state from localStorage.
+    // After a reload the toggle restores its state from localStorage.
     await page.reload();
     await expect(
-      page.getByRole('checkbox', { name: 'Auto-advance to next chapter' }),
-    ).toBeChecked();
+      page.getByRole('button', { name: 'Auto-advance to next chapter' }),
+    ).toHaveAttribute('aria-pressed', 'true');
   });
 
   test('manual chapter change does not auto-resume when auto-advance is on', async ({
@@ -507,15 +507,15 @@ test.describe('Lecture Learn', () => {
     await page.goto(`/#/learn/${lectureId}`);
 
     await page
-      .getByRole('checkbox', { name: 'Auto-advance to next chapter' })
-      .check();
+      .getByRole('button', { name: 'Auto-advance to next chapter' })
+      .click();
     await page.getByRole('button', { name: 'Auto-play chapter' }).click();
     await expect(
       page.getByRole('button', { name: 'Auto-play chapter' }),
     ).toHaveCount(0);
 
     // Manually jump to the next chapter while chapter 1 is still playing.
-    await page.getByRole('button', { name: 'Next' }).click();
+    await page.getByRole('button', { name: 'Next', exact: true }).click();
     await expect(page).toHaveURL(new RegExp(`/learn/${lectureId}/c2`));
 
     // The manual jump must not trigger an auto-resume — chapter 2 stays idle.
@@ -593,8 +593,8 @@ test.describe('Lecture Learn', () => {
     await page.goto(`/#/learn/${lectureId}/c2`);
 
     await page
-      .getByRole('checkbox', { name: 'Auto-advance to next chapter' })
-      .check();
+      .getByRole('button', { name: 'Auto-advance to next chapter' })
+      .click();
     await page.getByRole('button', { name: 'Auto-play chapter' }).click();
 
     // Playback finishes; with no next chapter the control returns to idle
@@ -769,8 +769,8 @@ test.describe('Lecture Learn', () => {
     await page.goto(`/#/learn/${lectureId}`);
 
     await page
-      .getByRole('checkbox', { name: 'Auto-advance to next chapter' })
-      .check();
+      .getByRole('button', { name: 'Auto-advance to next chapter' })
+      .click();
     await page.getByRole('button', { name: 'Auto-play chapter' }).click();
 
     // The chain advances c1 -> c2 -> c3, playing each chapter in turn.
@@ -863,8 +863,8 @@ test.describe('Lecture Learn', () => {
     // Enabling the preference now must not retroactively trigger a jump —
     // only a fresh chapter completion may advance.
     await page
-      .getByRole('checkbox', { name: 'Auto-advance to next chapter' })
-      .check();
+      .getByRole('button', { name: 'Auto-advance to next chapter' })
+      .click();
     await page.waitForTimeout(500);
     await expect(page).toHaveURL(new RegExp(`/learn/${lectureId}/c1`));
   });


### PR DESCRIPTION
## Context

In Learn mode, the chapter header renders a row of controls: the **Play** (`VoicePlaybackButton`) and **Auto Advance** (`AutoAdvanceToggle`) controls, an association badge, and the existing **edit** icon button.

The two voice controls were built as bespoke "compact icon pills" (`bg-surface`, no shadow, hover-to-expand label) and did not match the established `IconButton` look used by the edit button (`rounded-full`, `bg-white/80`, `shadow-md`, square padding, primary hover). The row looked inconsistent.

## Changes

- **`IconButton`** — added an optional `iconClassName` prop so callers can style the icon itself (loading-spinner animation, state color tints).
- **`VoicePlaybackButton`** — rewritten to compose `IconButton`. Label moved to `aria-label`/`title`. States: idle = default look, loading = spinning icon, playing/paused = primary tint, error = `danger` variant + red tint.
- **`AutoAdvanceToggle`** — rewritten to compose `IconButton` as a toggle button with `aria-pressed` (replacing the `<label>`+checkbox). Enabled state shows a primary tint.
- **Tests** — updated to assert accessible names and `aria-pressed` instead of visible label text / checkbox role.

Result: Play, Auto Advance, and the edit button now form one consistent circular-icon-button row.

## Verification

- `vitest run` — 19/19 component tests pass
- `eslint` + `tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)