### PR TITLE
feat(learn): default auto-advance on and align voice controls with edit

### DIFF
--- a/apps/web/src/pages/LectureLearn.tsx
+++ b/apps/web/src/pages/LectureLearn.tsx
@@ -27,13 +27,15 @@ export const LectureLearn = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   // Hands-free preference: continue voice playback into the next chapter.
+  // Defaults to on; an explicit stored value overrides the default.
   // Storage access is guarded — private mode / disabled storage must not crash
   // the page; the preference simply falls back to session-only in that case.
   const [autoAdvance, setAutoAdvance] = useState(() => {
     try {
-      return localStorage.getItem('learnAutoAdvance') === 'true';
+      const stored = localStorage.getItem('learnAutoAdvance');
+      return stored === null ? true : stored === 'true';
     } catch {
-      return false;
+      return true;
     }
   });
   // Set when an auto-advance navigation happens so the next chapter resumes
@@ -350,6 +352,11 @@ export const LectureLearn = () => {
                       {currentFirstQuestion?.question || t('common.untitled')}
                     </h2>
                     <div className="flex flex-wrap items-center gap-2">
+                      {currentChapter.association && (
+                        <span className="px-3 py-1 text-sm font-medium bg-primary-100 text-primary-700 rounded-full">
+                          {currentChapter.association}
+                        </span>
+                      )}
                       {speechConfigured &&
                         currentChapterQuestions.length > 0 && (
                           <>
@@ -365,11 +372,6 @@ export const LectureLearn = () => {
                             />
                           </>
                         )}
-                      {currentChapter.association && (
-                        <span className="px-3 py-1 text-sm font-medium bg-primary-100 text-primary-700 rounded-full">
-                          {currentChapter.association}
-                        </span>
-                      )}
                       <ChapterMenu chapter={currentChapter} lectureId={id!} />
                     </div>
                   </div>

--- a/apps/web/tests/lecture-learn.spec.ts
+++ b/apps/web/tests/lecture-learn.spec.ts
@@ -283,10 +283,7 @@ test.describe('Lecture Learn', () => {
 
     await page.goto(`/#/learn/${lectureId}`);
 
-    // Enable auto-advance, then start playback on chapter 1.
-    await page
-      .getByRole('button', { name: 'Auto-advance to next chapter' })
-      .click();
+    // Auto-advance is on by default; just start playback on chapter 1.
     await page.getByRole('button', { name: 'Auto-play chapter' }).click();
 
     // Chapter 1 finishes -> app advances to chapter 2 and resumes playback.
@@ -364,9 +361,7 @@ test.describe('Lecture Learn', () => {
 
     await page.goto(`/#/learn/${lectureId}`);
 
-    await page
-      .getByRole('button', { name: 'Auto-advance to next chapter' })
-      .click();
+    // Auto-advance is on by default; just start playback.
     await page.getByRole('button', { name: 'Auto-play chapter' }).click();
 
     // Chapter 1 finishes -> empty chapter 2 is skipped -> chapter 3 plays.
@@ -421,19 +416,20 @@ test.describe('Lecture Learn', () => {
     const toggle = page.getByRole('button', {
       name: 'Auto-advance to next chapter',
     });
-    await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+    // Auto-advance is on by default; toggling it off must persist.
+    await expect(toggle).toHaveAttribute('aria-pressed', 'true');
     await toggle.click();
 
     // The preference is written to localStorage.
     expect(
       await page.evaluate(() => localStorage.getItem('learnAutoAdvance')),
-    ).toBe('true');
+    ).toBe('false');
 
     // After a reload the toggle restores its state from localStorage.
     await page.reload();
     await expect(
       page.getByRole('button', { name: 'Auto-advance to next chapter' }),
-    ).toHaveAttribute('aria-pressed', 'true');
+    ).toHaveAttribute('aria-pressed', 'false');
   });
 
   test('manual chapter change does not auto-resume when auto-advance is on', async ({
@@ -506,9 +502,7 @@ test.describe('Lecture Learn', () => {
 
     await page.goto(`/#/learn/${lectureId}`);
 
-    await page
-      .getByRole('button', { name: 'Auto-advance to next chapter' })
-      .click();
+    // Auto-advance is on by default; just start playback.
     await page.getByRole('button', { name: 'Auto-play chapter' }).click();
     await expect(
       page.getByRole('button', { name: 'Auto-play chapter' }),
@@ -592,9 +586,7 @@ test.describe('Lecture Learn', () => {
     // Start directly on the last chapter.
     await page.goto(`/#/learn/${lectureId}/c2`);
 
-    await page
-      .getByRole('button', { name: 'Auto-advance to next chapter' })
-      .click();
+    // Auto-advance is on by default; just start playback.
     await page.getByRole('button', { name: 'Auto-play chapter' }).click();
 
     // Playback finishes; with no next chapter the control returns to idle
@@ -669,7 +661,10 @@ test.describe('Lecture Learn', () => {
 
     await page.goto(`/#/learn/${lectureId}/c1`);
 
-    // Auto-advance is left at its default (off); just start playback.
+    // Turn auto-advance off (it is on by default), then start playback.
+    await page
+      .getByRole('button', { name: 'Auto-advance to next chapter' })
+      .click();
     await page.getByRole('button', { name: 'Auto-play chapter' }).click();
 
     // Playback finishes; without auto-advance the app stays on chapter 1.
@@ -768,9 +763,7 @@ test.describe('Lecture Learn', () => {
 
     await page.goto(`/#/learn/${lectureId}`);
 
-    await page
-      .getByRole('button', { name: 'Auto-advance to next chapter' })
-      .click();
+    // Auto-advance is on by default; just start playback.
     await page.getByRole('button', { name: 'Auto-play chapter' }).click();
 
     // The chain advances c1 -> c2 -> c3, playing each chapter in turn.
@@ -853,14 +846,18 @@ test.describe('Lecture Learn', () => {
 
     await page.goto(`/#/learn/${lectureId}/c1`);
 
-    // Auto-advance left at its default (off); play chapter 1 to completion.
+    // Turn auto-advance off (it is on by default), then play chapter 1
+    // to completion.
+    await page
+      .getByRole('button', { name: 'Auto-advance to next chapter' })
+      .click();
     await page.getByRole('button', { name: 'Auto-play chapter' }).click();
     await expect(
       page.getByRole('button', { name: 'Auto-play chapter' }),
     ).toBeVisible({ timeout: 15000 });
     await expect(page).toHaveURL(new RegExp(`/learn/${lectureId}/c1`));
 
-    // Enabling the preference now must not retroactively trigger a jump —
+    // Re-enabling the preference now must not retroactively trigger a jump —
     // only a fresh chapter completion may advance.
     await page
       .getByRole('button', { name: 'Auto-advance to next chapter' })

--- a/apps/web/tests/lecture-learn.spec.ts
+++ b/apps/web/tests/lecture-learn.spec.ts
@@ -432,6 +432,68 @@ test.describe('Lecture Learn', () => {
     ).toHaveAttribute('aria-pressed', 'false');
   });
 
+  test('auto-advance defaults to on, and a stored preference overrides it', async ({
+    page,
+  }) => {
+    const lectureId = 'lecture-1';
+    const lecture = {
+      id: lectureId,
+      title: 'Default Lecture',
+      description: 'D',
+    };
+    const chapters = [{ id: 'c1', lectureId, order: 0, association: '' }];
+    const firstQuestions = { c1: { question: 'Chapter 1 Intro' } };
+    const c1Questions = [
+      {
+        id: 'q1',
+        chapterId: 'c1',
+        question: 'Chapter 1 Intro',
+        answer: 'Answer 1',
+        order: 0,
+      },
+    ];
+
+    await page.route('**/api/trpc/lectures.getLecture?*', async (route) => {
+      await route.fulfill({ json: { result: { data: lecture } } });
+    });
+    await page.route('**/api/trpc/chapters.getChapters*', async (route) => {
+      await route.fulfill({ json: { result: { data: chapters } } });
+    });
+    await page.route(
+      '**/api/trpc/questions.getFirstQuestionsByLecture*',
+      async (route) => {
+        await route.fulfill({ json: { result: { data: firstQuestions } } });
+      },
+    );
+    await page.route('**/api/trpc/questions.getQuestions?*', async (route) => {
+      await route.fulfill({ json: { result: { data: c1Questions } } });
+    });
+    await page.route('**/api/trpc/speech.isConfigured*', async (route) => {
+      await route.fulfill({ json: { result: { data: true } } });
+    });
+
+    const toggle = page.getByRole('button', {
+      name: 'Auto-advance to next chapter',
+    });
+
+    // With no stored preference the toggle defaults to on.
+    await page.goto(`/#/learn/${lectureId}`);
+    await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+
+    // An explicit 'false' preference must override the on-by-default —
+    // existing users who turned auto-advance off keep it off.
+    await page.evaluate(() =>
+      localStorage.setItem('learnAutoAdvance', 'false'),
+    );
+    await page.reload();
+    await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+
+    // An explicit 'true' preference also wins, matching the default.
+    await page.evaluate(() => localStorage.setItem('learnAutoAdvance', 'true'));
+    await page.reload();
+    await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+  });
+
   test('manual chapter change does not auto-resume when auto-advance is on', async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary
- Move the voice playback and auto-advance icon controls so they sit directly next to the chapter edit button. The association badge now comes first, giving the icon controls consistent alignment.
- Auto-advance now **defaults to on**. An explicit stored preference in `localStorage` still overrides the default, so users who previously turned it off keep their setting.

## Changes
- `LectureLearn.tsx`: reorder the header controls (association badge → play → auto-advance → edit) and change the `autoAdvance` initial state to default `true` when no stored preference exists.
- `lecture-learn.spec.ts`: update e2e tests to reflect the new default — tests that need auto-advance off now toggle it off explicitly, and the persistence test verifies the on→off flow.

## Testing
- `pnpm test` — 115 unit tests pass
- `pnpm exec playwright test lecture-learn` — 11 e2e tests pass
- `tsc --noEmit` and `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)