### PR TITLE
feat(tts): wire Chirp3-HD pause control via markup field

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -6,7 +6,8 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
     "lint": "eslint .",
-    "format": "prettier --write \"src/**/*.ts\" \"*.{js,ts,json}\""
+    "format": "prettier --write \"src/**/*.ts\" \"*.{js,ts,json}\"",
+    "test": "vitest run"
   },
   "dependencies": {
     "@athena/api": "workspace:*",
@@ -26,6 +27,7 @@
     "@types/node": "^25.9.1",
     "eslint": "^9.39.4",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.0"
   }
 }

--- a/apps/server/src/google-speech.ts
+++ b/apps/server/src/google-speech.ts
@@ -169,9 +169,10 @@ export function createGoogleSpeechService(): SpeechService | undefined {
       const accessToken = await getAccessToken();
 
       async function synthesizeChunk(chunk: string): Promise<Buffer> {
-        // `input.markup` is required to honor `[pause …]` markers; for chunks
-        // without any marker, stay on `text` to avoid the markup code path.
-        const inputField = chunk.includes('[pause')
+        // `input.markup` is required to honor `[pause …]` markers; match a
+        // complete token so user content containing the literal `[pause` (e.g.
+        // a code block discussing markup) stays on the plain-text path.
+        const inputField = /\[pause(?: short| long)?\]/.test(chunk)
           ? { markup: chunk }
           : { text: chunk };
         const response = await fetch(GOOGLE_TTS_ENDPOINT, {

--- a/apps/server/src/google-speech.ts
+++ b/apps/server/src/google-speech.ts
@@ -3,7 +3,11 @@ import * as fs from 'node:fs';
 
 import type { SpeechFormat, SpeechResult, SpeechService } from '@athena/api';
 
-import { chunkText, estimateDuration, ssmlToChirp3Markup } from './tts-utils.js';
+import {
+  chunkText,
+  estimateDuration,
+  ssmlToChirp3Markup,
+} from './tts-utils.js';
 
 const GOOGLE_TTS_ENDPOINT =
   'https://texttospeech.googleapis.com/v1/text:synthesize';

--- a/apps/server/src/google-speech.ts
+++ b/apps/server/src/google-speech.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs';
 
 import type { SpeechFormat, SpeechResult, SpeechService } from '@athena/api';
 
-import { chunkText, estimateDuration, stripSsml } from './tts-utils.js';
+import { chunkText, estimateDuration, ssmlToChirp3Markup } from './tts-utils.js';
 
 const GOOGLE_TTS_ENDPOINT =
   'https://texttospeech.googleapis.com/v1/text:synthesize';
@@ -145,9 +145,10 @@ export function createGoogleSpeechService(): SpeechService | undefined {
       language: 'de' | 'en',
       format: SpeechFormat = 'text',
     ): Promise<SpeechResult> {
-      // Chirp 3 HD only supports phoneme/say-as/sub/p/s SSML tags, not the
-      // emphasis/break/prosody tags `markdownToSsml` emits, so fall back to text.
-      const input = format === 'ssml' ? stripSsml(text) : text;
+      // Chirp 3 HD doesn't accept SSML `<break>`/`<emphasis>`/`<prosody>`, but
+      // it does accept inline `[pause …]` markers via `input.markup`. Convert
+      // the SSML body so structural pauses survive; plain text passes through.
+      const input = format === 'ssml' ? ssmlToChirp3Markup(text) : text;
       const voice = voiceOverride || DEFAULT_VOICE[language];
       const chunks = chunkText(input, MAX_INPUT_BYTES);
       console.log(
@@ -164,6 +165,11 @@ export function createGoogleSpeechService(): SpeechService | undefined {
       const accessToken = await getAccessToken();
 
       async function synthesizeChunk(chunk: string): Promise<Buffer> {
+        // `input.markup` is required to honor `[pause …]` markers; for chunks
+        // without any marker, stay on `text` to avoid the markup code path.
+        const inputField = chunk.includes('[pause')
+          ? { markup: chunk }
+          : { text: chunk };
         const response = await fetch(GOOGLE_TTS_ENDPOINT, {
           method: 'POST',
           headers: {
@@ -171,7 +177,7 @@ export function createGoogleSpeechService(): SpeechService | undefined {
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({
-            input: { text: chunk },
+            input: inputField,
             voice: { languageCode: LANGUAGE_CODE[language], name: voice },
             audioConfig: { audioEncoding: 'MP3' },
           }),

--- a/apps/server/src/tts-utils.test.ts
+++ b/apps/server/src/tts-utils.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import { chunkText, ssmlToChirp3Markup } from './tts-utils.js';
+
+describe('ssmlToChirp3Markup', () => {
+  it('maps a long break (>=800ms) to [pause long]', () => {
+    expect(ssmlToChirp3Markup('a<break time="900ms"/>b')).toBe(
+      'a [pause long] b',
+    );
+  });
+
+  it('maps a default break (400–799ms) to [pause]', () => {
+    expect(ssmlToChirp3Markup('a<break time="600ms"/>b')).toBe('a [pause] b');
+  });
+
+  it('maps a short break (<400ms) to [pause short]', () => {
+    expect(ssmlToChirp3Markup('a<break time="200ms"/>b')).toBe(
+      'a [pause short] b',
+    );
+  });
+
+  it('treats 400ms as the lower bound of [pause]', () => {
+    expect(ssmlToChirp3Markup('a<break time="400ms"/>b')).toBe('a [pause] b');
+  });
+
+  it('treats 799ms as still [pause]', () => {
+    expect(ssmlToChirp3Markup('a<break time="799ms"/>b')).toBe('a [pause] b');
+  });
+
+  it('treats 800ms as the lower bound of [pause long]', () => {
+    expect(ssmlToChirp3Markup('a<break time="800ms"/>b')).toBe(
+      'a [pause long] b',
+    );
+  });
+
+  it('treats 399ms as still [pause short]', () => {
+    expect(ssmlToChirp3Markup('a<break time="399ms"/>b')).toBe(
+      'a [pause short] b',
+    );
+  });
+
+  it('strips <emphasis> but keeps the inner text', () => {
+    const out = ssmlToChirp3Markup('Hello <emphasis level="strong">World</emphasis>');
+    expect(out).toBe('Hello World');
+  });
+
+  it('strips <prosody> but keeps the inner text', () => {
+    const out = ssmlToChirp3Markup('Run <prosody rate="-20%">npm install</prosody> now');
+    expect(out).toBe('Run npm install now');
+  });
+
+  it('decodes XML entities', () => {
+    expect(ssmlToChirp3Markup('a &amp; b &lt; c &gt; d &quot;e&quot; &apos;f&apos;')).toBe(
+      'a & b < c > d "e" \'f\'',
+    );
+  });
+
+  it('decodes &amp; last so &amp;gt; becomes &gt; (not >)', () => {
+    expect(ssmlToChirp3Markup('x &amp;gt; y')).toBe('x &gt; y');
+  });
+
+  it('passes plain (non-SSML) input through, trimmed', () => {
+    expect(ssmlToChirp3Markup('  just plain text  ')).toBe('just plain text');
+  });
+
+  it('preserves composite ordering of words and pause markers', () => {
+    const out = ssmlToChirp3Markup(
+      'Hello<break time="600ms"/><emphasis level="strong">World</emphasis><break time="900ms"/>',
+    );
+    expect(out).toContain('Hello');
+    expect(out).toContain('[pause]');
+    expect(out).toContain('World');
+    expect(out).toContain('[pause long]');
+    // Order check.
+    const idxHello = out.indexOf('Hello');
+    const idxPause = out.indexOf('[pause]');
+    const idxWorld = out.indexOf('World');
+    const idxLong = out.indexOf('[pause long]');
+    expect(idxHello).toBeLessThan(idxPause);
+    expect(idxPause).toBeLessThan(idxWorld);
+    expect(idxWorld).toBeLessThan(idxLong);
+  });
+});
+
+describe('chunkText with Chirp3 markup', () => {
+  it('never splits a [pause …] token across chunks', () => {
+    // Build a body well over the byte budget so chunking actually happens.
+    const sentence = 'This is a moderately long sentence used to fill bytes. ';
+    const body = (sentence.repeat(20) + '[pause long] ' + sentence.repeat(20)).trim();
+    const chunks = chunkText(body, 200);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      // Any `[` in a chunk must be followed by a complete `[pause …]` token.
+      const tokens = chunk.match(/\[[^\]]*\]?/g) ?? [];
+      for (const token of tokens) {
+        expect(token).toMatch(/^\[pause( short| long)?\]$/);
+      }
+    }
+  });
+});

--- a/apps/server/src/tts-utils.test.ts
+++ b/apps/server/src/tts-utils.test.ts
@@ -40,19 +40,23 @@ describe('ssmlToChirp3Markup', () => {
   });
 
   it('strips <emphasis> but keeps the inner text', () => {
-    const out = ssmlToChirp3Markup('Hello <emphasis level="strong">World</emphasis>');
+    const out = ssmlToChirp3Markup(
+      'Hello <emphasis level="strong">World</emphasis>',
+    );
     expect(out).toBe('Hello World');
   });
 
   it('strips <prosody> but keeps the inner text', () => {
-    const out = ssmlToChirp3Markup('Run <prosody rate="-20%">npm install</prosody> now');
+    const out = ssmlToChirp3Markup(
+      'Run <prosody rate="-20%">npm install</prosody> now',
+    );
     expect(out).toBe('Run npm install now');
   });
 
   it('decodes XML entities', () => {
-    expect(ssmlToChirp3Markup('a &amp; b &lt; c &gt; d &quot;e&quot; &apos;f&apos;')).toBe(
-      'a & b < c > d "e" \'f\'',
-    );
+    expect(
+      ssmlToChirp3Markup('a &amp; b &lt; c &gt; d &quot;e&quot; &apos;f&apos;'),
+    ).toBe('a & b < c > d "e" \'f\'');
   });
 
   it('decodes &amp; last so &amp;gt; becomes &gt; (not >)', () => {
@@ -86,7 +90,11 @@ describe('chunkText with Chirp3 markup', () => {
   it('never splits a [pause …] token across chunks', () => {
     // Build a body well over the byte budget so chunking actually happens.
     const sentence = 'This is a moderately long sentence used to fill bytes. ';
-    const body = (sentence.repeat(20) + '[pause long] ' + sentence.repeat(20)).trim();
+    const body = (
+      sentence.repeat(20) +
+      '[pause long] ' +
+      sentence.repeat(20)
+    ).trim();
     const chunks = chunkText(body, 200);
     expect(chunks.length).toBeGreaterThan(1);
     for (const chunk of chunks) {

--- a/apps/server/src/tts-utils.test.ts
+++ b/apps/server/src/tts-utils.test.ts
@@ -87,8 +87,7 @@ describe('ssmlToChirp3Markup', () => {
 });
 
 describe('chunkText with Chirp3 markup', () => {
-  it('never splits a [pause …] token across chunks', () => {
-    // Build a body well over the byte budget so chunking actually happens.
+  it('never splits a [pause …] token across chunks at sentence boundaries', () => {
     const sentence = 'This is a moderately long sentence used to fill bytes. ';
     const body = (
       sentence.repeat(20) +
@@ -97,12 +96,34 @@ describe('chunkText with Chirp3 markup', () => {
     ).trim();
     const chunks = chunkText(body, 200);
     expect(chunks.length).toBeGreaterThan(1);
-    for (const chunk of chunks) {
-      // Any `[` in a chunk must be followed by a complete `[pause …]` token.
-      const tokens = chunk.match(/\[[^\]]*\]?/g) ?? [];
-      for (const token of tokens) {
-        expect(token).toMatch(/^\[pause( short| long)?\]$/);
-      }
-    }
+    assertPauseTokensIntact(chunks);
+  });
+
+  it('keeps [pause …] atomic inside an over-long unpunctuated sentence', () => {
+    // No `.!?` anywhere, so chunkText falls through to the word-splitting
+    // branch — the only path where a marker could be torn in half.
+    const clause = 'word '.repeat(80);
+    const body = (clause + '[pause long] ' + clause).trim();
+    const chunks = chunkText(body, 200);
+    expect(chunks.length).toBeGreaterThan(1);
+    assertPauseTokensIntact(chunks);
+    // And the marker must appear, intact, in exactly one chunk.
+    const withMarker = chunks.filter((c) => c.includes('[pause long]'));
+    expect(withMarker).toHaveLength(1);
   });
 });
+
+function assertPauseTokensIntact(chunks: string[]): void {
+  for (const chunk of chunks) {
+    // Any `[` or `]` in a chunk must belong to a complete `[pause …]` token.
+    const fragments = chunk.match(/\[[^\]]*\]?|\][^[]*/g) ?? [];
+    for (const fragment of fragments) {
+      if (fragment.startsWith('[')) {
+        expect(fragment).toMatch(/^\[pause( short| long)?\]$/);
+      } else {
+        // A bare `]` with no preceding `[` means a token was torn.
+        expect(fragment).not.toMatch(/^\]/);
+      }
+    }
+  }
+}

--- a/apps/server/src/tts-utils.ts
+++ b/apps/server/src/tts-utils.ts
@@ -22,6 +22,33 @@ export function stripSsml(body: string): string {
     .trim();
 }
 
+/**
+ * Converts an SSML body to a Chirp 3 HD markup body. `<break time="…ms"/>`
+ * tags become inline `[pause …]` markers — the only structural pause control
+ * Chirp 3 HD accepts; every other tag (`<emphasis>`, `<prosody>`, …) is
+ * stripped so its inner text is still spoken. Plain input passes through.
+ *
+ * Tier mapping is duration-based so the single source of truth stays in
+ * `markdownToSsml`: ≥800ms → long, 400–799ms → default, <400ms → short.
+ */
+export function ssmlToChirp3Markup(body: string): string {
+  return body
+    .replace(/<break\s+time="(\d+)ms"\s*\/>/g, (_match, ms: string) => {
+      const duration = Number(ms);
+      if (duration >= 800) return ' [pause long] ';
+      if (duration >= 400) return ' [pause] ';
+      return ' [pause short] ';
+    })
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
 /** Rough duration estimate in ms; `SpeechResult.duration` is unused client-side. */
 export function estimateDuration(text: string): number {
   const words = text.split(/\s+/).filter(Boolean).length;

--- a/apps/server/src/tts-utils.ts
+++ b/apps/server/src/tts-utils.ts
@@ -2,27 +2,6 @@
 const WORDS_PER_SECOND = 2.5;
 
 /**
- * Strips SSML markup down to plain text. `markdownToSsml` only emits
- * `<emphasis>`, `<break>` and `<prosody>` tags; adapters whose provider does
- * not support those tags call this to fall back to clean, readable text.
- *
- * XML entities are decoded back to their characters so the provider speaks
- * them naturally rather than reading the literal `&gt;` / `&amp;`. `&amp;`
- * is decoded last so an encoded entity like `&amp;gt;` is not double-decoded.
- */
-export function stripSsml(body: string): string {
-  return body
-    .replace(/<[^>]*>/g, ' ')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&apos;/g, "'")
-    .replace(/&amp;/g, '&')
-    .replace(/\s+/g, ' ')
-    .trim();
-}
-
-/**
  * Converts an SSML body to a Chirp 3 HD markup body. `<break time="…ms"/>`
  * tags become inline `[pause …]` markers — the only structural pause control
  * Chirp 3 HD accepts; every other tag (`<emphasis>`, `<prosody>`, …) is
@@ -82,12 +61,13 @@ export function chunkText(text: string, maxBytes: number): string[] {
       current = sentence;
       continue;
     }
-    // Sentence alone exceeds the limit: pack it word by word.
-    for (const word of sentence.split(/(\s+)/)) {
-      if (current && Buffer.byteLength(current + word, 'utf8') > maxBytes) {
+    // Sentence alone exceeds the limit: pack it word by word. Keep
+    // `[pause …]` markers atomic so the Chirp 3 markup token survives.
+    for (const piece of sentence.split(/(\[pause(?: short| long)?\]|\s+)/)) {
+      if (current && Buffer.byteLength(current + piece, 'utf8') > maxBytes) {
         flush();
       }
-      current += word;
+      current += piece;
     }
   }
   flush();

--- a/apps/web/src/utils/markdownToSsml.test.ts
+++ b/apps/web/src/utils/markdownToSsml.test.ts
@@ -16,6 +16,28 @@ describe('markdownToSsml', () => {
   it('maps headings to strong emphasis', () => {
     const ssml = markdownToSsml('# Big Title');
     expect(ssml).toContain('<emphasis level="strong">Big Title</emphasis>');
+    expect(ssml).toContain('<break time="900ms"/>');
+  });
+
+  it('emits a long break for H2 headings', () => {
+    const ssml = markdownToSsml('## Sub');
+    expect(ssml).toContain('<emphasis level="strong">Sub</emphasis>');
+    expect(ssml).toContain('<break time="900ms"/>');
+  });
+
+  it('keeps the paragraph-tier break for H3 and below', () => {
+    const ssml = markdownToSsml('### Sub-sub');
+    expect(ssml).toContain('<emphasis level="strong">Sub-sub</emphasis>');
+    expect(ssml).toContain('<break time="600ms"/>');
+    expect(ssml).not.toContain('<break time="900ms"/>');
+  });
+
+  it('wraps blockquotes with surrounding breaks', () => {
+    const ssml = markdownToSsml('> a quote');
+    // Leading + trailing break around the quoted content.
+    expect(ssml).toMatch(
+      /<break time="600ms"\/>\s*a quote\s*<break time="600ms"\/>/,
+    );
   });
 
   it('maps bold text to strong emphasis', () => {

--- a/apps/web/src/utils/markdownToSsml.ts
+++ b/apps/web/src/utils/markdownToSsml.ts
@@ -18,6 +18,7 @@ interface MdNode {
   type: string;
   value?: string;
   url?: string;
+  depth?: number;
   children?: MdNode[];
 }
 
@@ -78,8 +79,12 @@ function renderNode(node: MdNode): string {
     case 'root':
       return renderChildren(node);
 
-    case 'heading':
-      return `${emphasize(renderChildren(node), 'strong')}<break time="600ms"/>`;
+    case 'heading': {
+      // H1/H2 get a longer pause so the server's ssml→markup converter maps
+      // them to `[pause long]`; H3+ stays at the paragraph tier.
+      const breakMs = (node.depth ?? 0) <= 2 ? '900ms' : '600ms';
+      return `${emphasize(renderChildren(node), 'strong')}<break time="${breakMs}"/>`;
+    }
 
     case 'paragraph':
       return `${renderChildren(node)}<break time="600ms"/>`;
@@ -113,8 +118,11 @@ function renderNode(node: MdNode): string {
       // A list item's paragraph child already emits a trailing break.
       return renderChildren(node);
 
-    case 'blockquote':
-      return renderChildren(node);
+    case 'blockquote': {
+      const inner = renderChildren(node);
+      if (!inner.trim()) return '';
+      return `<break time="600ms"/>${inner}<break time="600ms"/>`;
+    }
 
     case 'thematicBreak':
       return '<break time="800ms"/>';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@types/node@25.9.1)(jsdom@29.0.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.98.0)(tsx@4.21.0))
 
   apps/web:
     dependencies:


### PR DESCRIPTION
## Summary

- Map markdown structure to inline `[pause …]` markers and submit via `input.markup` so Google Chirp3-HD voices honor structural pauses ([docs](https://docs.cloud.google.com/text-to-speech/docs/chirp3-hd#pause_control)). Previously the Google adapter stripped every `<break>` and sent flat text.
- Heading depth now drives a longer break: H1/H2 → 900ms (`[pause long]` on Google, audibly stronger on Azure too); H3+ stays at 600ms. Blockquotes get the leading + trailing break they were missing.
- Tier mapping is duration-based and lives once on the server (`ssmlToChirp3Markup` in `apps/server/src/tts-utils.ts`): ≥800ms → `[pause long]`, 400–799ms → `[pause]`, <400ms → `[pause short]`. `markdownToSsml` remains the single source of truth for which element gets which break.
- Per-chunk: the Google adapter only switches to `input.markup` when a chunk contains a complete `[pause …]` token; plain chunks (and chunks where the user happens to write the literal substring `[pause`) stay on `input.text` so the change is additive.
- Cross-provider note: the longer H1/H2 break (600→900ms) and the new blockquote surround are intentional improvements on the Azure path too, not Google-only side-effects of the Chirp3 wiring.

## Review follow-ups

- `chunkText` now treats `[pause …]` as atomic in its word-splitting fallback, so a marker inside a long unpunctuated sentence can no longer be torn across chunks. Added a test that exercises that branch directly.
- Tightened the `input.markup` vs `input.text` predicate to match a complete pause token (`/\[pause(?: short| long)?\]/`) instead of the literal substring `[pause`.
- Removed `stripSsml` — `ssmlToChirp3Markup` is now its only caller-equivalent, and the project has no other non-SSML adapter using it.

## Test plan

- [x] `pnpm --filter server test` — 15/15 pass (tiers, ms boundaries 399/400/799/800, `<emphasis>`/`<prosody>` strip, entity decode incl. `&amp;gt;` → `&gt;`, plain passthrough, composite ordering, `chunkText` `[pause …]` token-integrity at sentence boundary **and** inside an over-long unpunctuated sentence).
- [x] `pnpm --filter web test` — 121/121 pass (markdownToSsml: H1/H2 = 900ms, H3 = 600ms, blockquote surround, no new tags introduced).
- [x] `tsc --noEmit` clean in both packages.
- [x] Manual smoke with `TTS_PROVIDER=google` + a service-account key: read an answer that has a heading, paragraph, list, code block and blockquote — heading and thematic-break pauses should be audibly longer than paragraph/list pauses.
- [x] Regression smoke with `TTS_PROVIDER=azure`: same answer still synthesizes; heading/blockquote pauses are perceptibly stronger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
