### PR TITLE
docs: refresh README and ARCHITECTURE to match current state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,7 +14,7 @@ This document outlines the architectural design, directory structure, and techni
 | **Backend**         | Fastify    | v5.8.x   | Low overhead web framework for Node.js.                         |
 | **Communication**   | tRPC       | v11.x    | End-to-end typesafe APIs.                                       |
 | **Database**        | SQLite     | v12.8.x  | Lightweight relational database, via `better-sqlite3`.          |
-| **Speech**          | Azure TTS  | v1.48.x  | Microsoft Cognitive Services SDK for SSML-driven synthesis.     |
+| **Speech**          | Pluggable  | —        | TTS provider selected via `TTS_PROVIDER` env var: Azure Cognitive Services SDK (SSML) or Google Cloud TTS REST (Chirp3-HD). |
 | **i18n**            | i18next    | v26.x    | UI translation framework (English + German with auto-detection).|
 | **Formatting**      | Prettier   | v3.x     | Opinionated code formatter.                                     |
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,15 +6,17 @@ This document outlines the architectural design, directory structure, and techni
 
 | Component           | Technology | Version | Description                                          |
 | :------------------ | :--------- | :------ | :--------------------------------------------------- |
-| **Language**        | TypeScript | v5.x    | Unified language for typical Full Stack type-safety. |
-| **Package Manager** | pnpm       | v9.0.x  | Fast, disk-efficient package manager.                |
-| **Monorepo**        | Turborepo  | latest  | High-performance build system.                       |
-| **Frontend**        | React      | v18.2.x | UI library using functional components and hooks.    |
-| **Build Tooling**   | Vite       | v5.x    | Fast frontend build tool.                            |
-| **Backend**         | Fastify    | v4.26.x | Low overhead web framework for Node.js.              |
-| **Communication**   | tRPC       | v10.x   | End-to-end typesafe APIs.                            |
-| **Database**        | SQLite     | Latest  | (Planned) Lightweight relational database.           |
-| **Formatting**      | Prettier   | v3.x    | Opinionated code formatter.                          |
+| **Language**        | TypeScript | v5.9.x   | Unified language for typical Full Stack type-safety.            |
+| **Package Manager** | pnpm       | v10.26.x | Fast, disk-efficient package manager.                           |
+| **Monorepo**        | Turborepo  | latest   | High-performance build system.                                  |
+| **Frontend**        | React      | v19.2.x  | UI library using functional components and hooks.               |
+| **Build Tooling**   | Vite       | v8.x     | Fast frontend build tool.                                       |
+| **Backend**         | Fastify    | v5.8.x   | Low overhead web framework for Node.js.                         |
+| **Communication**   | tRPC       | v11.x    | End-to-end typesafe APIs.                                       |
+| **Database**        | SQLite     | v12.8.x  | Lightweight relational database, via `better-sqlite3`.          |
+| **Speech**          | Azure TTS  | v1.48.x  | Microsoft Cognitive Services SDK for SSML-driven synthesis.     |
+| **i18n**            | i18next    | v26.x    | UI translation framework (English + German with auto-detection).|
+| **Formatting**      | Prettier   | v3.x     | Opinionated code formatter.                                     |
 
 ## **2. Repository Structure**
 
@@ -27,6 +29,7 @@ The repository is organized into `apps` (deployable applications) and `packages`
 │   └── server/       # Backend server (Fastify + tRPC)
 ├── packages/
 │   ├── api/          # Shared tRPC router and procedure definitions
+│   ├── eslint-config/ # Shared ESLint config
 │   └── typescript-config/ # Shared TSConfig bases
 ├── package.json      # Root manifest (Workspaces + Turbo config)
 ├── pnpm-workspace.yaml # Monorepo workspace definition
@@ -41,6 +44,7 @@ The repository is organized into `apps` (deployable applications) and `packages`
 ### **2.2 Packages**
 
 - **api**: Contains the `appRouter` definition, Zod schemas, and context creators. This is imported by `server` (to implement) and `web` (to consume types), ensuring perfect type synchronization.
+- **eslint-config**: Shared ESLint flat-config presets consumed by every workspace.
 - **typescript-config**: Centralized `tsconfig.json` files to ensure consistent compiler options across the monorepo.
 
 ## **3. UI Design Guidelines**
@@ -69,7 +73,8 @@ Testing is a critical part of the architecture and should follow this split:
 
 - **Tool**: [Playwright](https://playwright.dev/).
 - **Scope**: Critical user journeys (Login, Data submission, etc.).
-- **Location**: A dedicated `e2e` folder or within `apps/web`.
+- **Location**: `apps/web/tests/`.
+- **Run**: `pnpm test:e2e` (root) or `pnpm --filter web test:e2e`.
 
 ## **5. Development Workflow**
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,12 @@ Athena uses a strict three-tier hierarchy to keep learning materials organized:
   - Front/Back card design for questions and answers.
   - Support for rich text, code snippets, and images.
 - **Voice Interaction & Evaluation:** The app reads questions aloud, allows users to respond via voice, and provides AI-driven evaluation on correctness and feedback.
-- **Training Mode:** Specific modes for reviewing cards (e.g., Shuffle, Spaced Repetition).
+  - Powered by Azure Cognitive Services TTS with SSML for fine-grained pacing and prosody, and support for multiple voices across English and German.
+- **Training Mode:** Shuffle/randomized review with auto-advance, and progress-aware ordering that surfaces unreviewed questions first.
 - **Progress Tracking:** Visual indicators of mastery for each topic.
+- **Localization:** Full UI in English and German, with browser-language auto-detection.
+- **Global Search:** Search chapters across all courses from anywhere in the app.
+- **Chapter Organization:** Tag chapters with associations (categories) and move chapters between courses.
 
 ## **🛠️ Tech Stack**
 
@@ -51,8 +55,11 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for more information on the architecture 
 
 ### **Installation**
 
-1. Clone the repository:  
-   git clone [https://github.com/esukram/athena.git](https://github.com/esukram/athena.git)
+1. Clone the repository:
+
+   ```
+   git clone https://github.com/esukram/athena.git
+   ```
 
 2. Navigate to the project directory:  
    cd athena

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Athena uses a strict three-tier hierarchy to keep learning materials organized:
   - Front/Back card design for questions and answers.
   - Support for rich text, code snippets, and images.
 - **Voice Interaction & Evaluation:** The app reads questions aloud, allows users to respond via voice, and provides AI-driven evaluation on correctness and feedback.
-  - Powered by Azure Cognitive Services TTS with SSML for fine-grained pacing and prosody, and support for multiple voices across English and German.
+  - Pluggable TTS backend selected via the `TTS_PROVIDER` env var — currently Azure Cognitive Services (SSML-driven) and Google Cloud TTS (Chirp3-HD with `[pause]` markup), with multi-voice support across English and German.
 - **Training Mode:** Shuffle/randomized review with auto-advance, and progress-aware ordering that surfaces unreviewed questions first.
 - **Progress Tracking:** Visual indicators of mastery for each topic.
 - **Localization:** Full UI in English and German, with browser-language auto-detection.


### PR DESCRIPTION
## Summary

- **README:** Remove the misleading "Spaced Repetition" claim (no SR algorithm exists — only an `isAnnotated` flag that reorders the queue). Document the actual training behavior and surface previously-undocumented user-facing features: i18n (DE/EN with auto-detection), global chapter search, chapter associations and chapter movement, and the Azure TTS + SSML speech pipeline. Fix the malformed `git clone` markdown.
- **ARCHITECTURE.md:** Update the version table to current reality (TypeScript 5.9, pnpm 10.26, React 19.2, Vite 8, Fastify 5.8, tRPC 11, better-sqlite3 12.8 — no longer "Planned"). Add rows for Azure TTS and i18next, add the missing `packages/eslint-config` to the repo tree and package descriptions, and point the E2E section at the real `apps/web/tests/` location with the `pnpm test:e2e` script.

## Test plan

- [x] Render both files (GitHub preview or local markdown viewer) and confirm formatting is clean
- [x] `rg "Spaced Repetition" README.md ARCHITECTURE.md` returns nothing
- [x] Spot-check that every newly-named file/component in the README exists in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)