### PR TITLE
fix(tts): address Chirp 3 markup regressions from #122

### DIFF
--- a/apps/server/src/google-speech.ts
+++ b/apps/server/src/google-speech.ts
@@ -6,6 +6,7 @@ import type { SpeechFormat, SpeechResult, SpeechService } from '@athena/api';
 import {
   chunkText,
   estimateDuration,
+  PAUSE_MARKER,
   ssmlToChirp3Markup,
 } from './tts-utils.js';
 
@@ -213,9 +214,7 @@ export function createGoogleSpeechService(): SpeechService | undefined {
       return {
         audioData: Buffer.concat(parts).toString('base64'),
         // Strip `[pause …]` markers so they don't inflate the spoken-word count.
-        duration: estimateDuration(
-          input.replace(/\[pause(?: short| long)?\]/g, ''),
-        ),
+        duration: estimateDuration(input.replace(PAUSE_MARKER, '')),
       };
     },
   };

--- a/apps/server/src/google-speech.ts
+++ b/apps/server/src/google-speech.ts
@@ -4,9 +4,9 @@ import * as fs from 'node:fs';
 import type { SpeechFormat, SpeechResult, SpeechService } from '@athena/api';
 
 import {
+  PAUSE_MARKER,
   chunkText,
   estimateDuration,
-  PAUSE_MARKER,
   ssmlToChirp3Markup,
 } from './tts-utils.js';
 

--- a/apps/server/src/google-speech.ts
+++ b/apps/server/src/google-speech.ts
@@ -168,13 +168,15 @@ export function createGoogleSpeechService(): SpeechService | undefined {
 
       const accessToken = await getAccessToken();
 
+      // Route by `format`, not by per-chunk content: `ssmlToChirp3Markup` is
+      // the only producer of `[pause …]` markers we trust, so SSML input goes
+      // through `input.markup`. Plain-text input must never be reinterpreted
+      // as markup — a user prompt containing the literal `[pause]` would
+      // otherwise be silenced instead of spoken.
+      const useMarkup = format === 'ssml';
+
       async function synthesizeChunk(chunk: string): Promise<Buffer> {
-        // `input.markup` is required to honor `[pause …]` markers; match a
-        // complete token so user content containing the literal `[pause` (e.g.
-        // a code block discussing markup) stays on the plain-text path.
-        const inputField = /\[pause(?: short| long)?\]/.test(chunk)
-          ? { markup: chunk }
-          : { text: chunk };
+        const inputField = useMarkup ? { markup: chunk } : { text: chunk };
         const response = await fetch(GOOGLE_TTS_ENDPOINT, {
           method: 'POST',
           headers: {
@@ -210,7 +212,10 @@ export function createGoogleSpeechService(): SpeechService | undefined {
 
       return {
         audioData: Buffer.concat(parts).toString('base64'),
-        duration: estimateDuration(input),
+        // Strip `[pause …]` markers so they don't inflate the spoken-word count.
+        duration: estimateDuration(
+          input.replace(/\[pause(?: short| long)?\]/g, ''),
+        ),
       };
     },
   };

--- a/apps/server/src/tts-utils.test.ts
+++ b/apps/server/src/tts-utils.test.ts
@@ -67,6 +67,15 @@ describe('ssmlToChirp3Markup', () => {
     expect(ssmlToChirp3Markup('  just plain text  ')).toBe('just plain text');
   });
 
+  it('accepts single-quoted break attributes', () => {
+    expect(ssmlToChirp3Markup("a<break time='600ms'/>b")).toBe('a [pause] b');
+  });
+
+  it('accepts breaks expressed in seconds', () => {
+    expect(ssmlToChirp3Markup('a<break time="1s"/>b')).toBe('a [pause long] b');
+    expect(ssmlToChirp3Markup('a<break time="0.5s"/>b')).toBe('a [pause] b');
+  });
+
   it('preserves composite ordering of words and pause markers', () => {
     const out = ssmlToChirp3Markup(
       'Hello<break time="600ms"/><emphasis level="strong">World</emphasis><break time="900ms"/>',

--- a/apps/server/src/tts-utils.ts
+++ b/apps/server/src/tts-utils.ts
@@ -1,6 +1,9 @@
 /** Average speaking rate (~150 wpm) used only to estimate clip duration. */
 const WORDS_PER_SECOND = 2.5;
 
+/** Matches a Chirp 3 HD pause marker token (`[pause]`, `[pause short]`, `[pause long]`). */
+export const PAUSE_MARKER = /\[pause(?: short| long)?\]/g;
+
 /**
  * Converts an SSML body to a Chirp 3 HD markup body. `<break time="…">` tags
  * become inline `[pause …]` markers — the structural pause control we use

--- a/apps/server/src/tts-utils.ts
+++ b/apps/server/src/tts-utils.ts
@@ -2,22 +2,27 @@
 const WORDS_PER_SECOND = 2.5;
 
 /**
- * Converts an SSML body to a Chirp 3 HD markup body. `<break time="…ms"/>`
- * tags become inline `[pause …]` markers — the only structural pause control
- * Chirp 3 HD accepts; every other tag (`<emphasis>`, `<prosody>`, …) is
- * stripped so its inner text is still spoken. Plain input passes through.
+ * Converts an SSML body to a Chirp 3 HD markup body. `<break time="…">` tags
+ * become inline `[pause …]` markers — the structural pause control we use
+ * with Chirp 3 HD. Every other tag (including `<emphasis>`/`<prosody>` and
+ * the Chirp-supported `<say-as>`/`<sub>`/`<p>`/`<s>`, which `markdownToSsml`
+ * does not emit today) is stripped so its inner text is still spoken. Plain
+ * input passes through.
  *
  * Tier mapping is duration-based so the single source of truth stays in
  * `markdownToSsml`: ≥800ms → long, 400–799ms → default, <400ms → short.
  */
 export function ssmlToChirp3Markup(body: string): string {
   return body
-    .replace(/<break\s+time="(\d+)ms"\s*\/>/g, (_match, ms: string) => {
-      const duration = Number(ms);
-      if (duration >= 800) return ' [pause long] ';
-      if (duration >= 400) return ' [pause] ';
-      return ' [pause short] ';
-    })
+    .replace(
+      /<break\s+time=["'](\d+(?:\.\d+)?)(ms|s)["']\s*\/?>/g,
+      (_match, num: string, unit: string) => {
+        const duration = unit === 's' ? Number(num) * 1000 : Number(num);
+        if (duration >= 800) return ' [pause long] ';
+        if (duration >= 400) return ' [pause] ';
+        return ' [pause short] ';
+      },
+    )
     .replace(/<[^>]*>/g, ' ')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
@@ -64,6 +69,7 @@ export function chunkText(text: string, maxBytes: number): string[] {
     // Sentence alone exceeds the limit: pack it word by word. Keep
     // `[pause …]` markers atomic so the Chirp 3 markup token survives.
     for (const piece of sentence.split(/(\[pause(?: short| long)?\]|\s+)/)) {
+      if (!piece) continue;
       if (current && Buffer.byteLength(current + piece, 'utf8') > maxBytes) {
         flush();
       }

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "src/**/*.test.ts"]
 }

--- a/apps/web/src/utils/markdownToSsml.test.ts
+++ b/apps/web/src/utils/markdownToSsml.test.ts
@@ -32,12 +32,13 @@ describe('markdownToSsml', () => {
     expect(ssml).not.toContain('<break time="900ms"/>');
   });
 
-  it('wraps blockquotes with surrounding breaks', () => {
+  it('renders a leading blockquote without artificial silence', () => {
     const ssml = markdownToSsml('> a quote');
-    // Leading + trailing break around the quoted content.
-    expect(ssml).toMatch(
-      /<break time="600ms"\/>\s*a quote\s*<break time="600ms"\/>/,
-    );
+    // The inner paragraph emits its own trailing break; the blockquote
+    // shouldn't prepend a leading break that produces silence at the start.
+    expect(ssml).not.toMatch(/^<break/);
+    expect(ssml).toContain('a quote');
+    expect(ssml).toContain('<break time="600ms"/>');
   });
 
   it('maps bold text to strong emphasis', () => {

--- a/apps/web/src/utils/markdownToSsml.ts
+++ b/apps/web/src/utils/markdownToSsml.ts
@@ -118,11 +118,11 @@ function renderNode(node: MdNode): string {
       // A list item's paragraph child already emits a trailing break.
       return renderChildren(node);
 
-    case 'blockquote': {
-      const inner = renderChildren(node);
-      if (!inner.trim()) return '';
-      return `<break time="600ms"/>${inner}<break time="600ms"/>`;
-    }
+    case 'blockquote':
+      // The inner paragraph already emits a trailing break; wrapping with
+      // extra breaks here both produces leading silence when the quote is the
+      // first block, and is absorbed by the adjacent-break collapse below.
+      return renderChildren(node);
 
     case 'thematicBreak':
       return '<break time="800ms"/>';

--- a/apps/web/src/utils/markdownToSsml.ts
+++ b/apps/web/src/utils/markdownToSsml.ts
@@ -74,6 +74,13 @@ function hasSpokenText(node: MdNode): boolean {
   }
 }
 
+/**
+ * Renders an mdast node to SSML. Note: only `<break>` tags survive the
+ * server-side `ssmlToChirp3Markup` pass — any other tag added here (e.g.
+ * `<say-as>` for dates/numbers) will be stripped to its inner text before
+ * Chirp 3 HD sees it. Coordinate with `apps/server/src/tts-utils.ts` if you
+ * introduce a new tag that needs to reach the synthesizer.
+ */
 function renderNode(node: MdNode): string {
   switch (node.type) {
     case 'root':


### PR DESCRIPTION
## Summary

Fixes verified regressions and overstated-but-real issues from PR #122 (`feat(tts): wire Chirp3-HD pause control via markup field`). All findings were surfaced by a max-effort code review and cross-checked by an independent reviewer (codex) against the live Google Chirp 3 HD docs.

- **User-typed `[pause]` regression** (`google-speech.ts`) — the per-chunk content detector matched any literal `[pause]` token in user prompts and routed the chunk to `input.markup`, so Chirp 3 silenced the literal. Now routes by `format === 'ssml'` (the only producer of markers we trust), which also eliminates mixed `markup`/`text` chunking across one SSML body.
- **Leading-silence blockquote regression** (`markdownToSsml.ts`) — the new `<break>` wrap on blockquotes prepended 600 ms of silence whenever a quote was the first block; the *trailing* `<break>` was absorbed by the adjacent-break collapse and contributed nothing. Reverted the wrap.
- **Tests compiled into `dist/`** (`apps/server/tsconfig.json`) — `tsc` was emitting `dist/tts-utils.test.js`, which vitest then double-discovered after a build and which shipped into the production bundle (importing the `vitest` devDep). Excluded `src/**/*.test.ts`.
- **`estimateDuration` inflated by markers** (`google-speech.ts`) — `[pause long]` was counted as two words. Now strips markers before counting.
- **Brittle `<break>` regex** (`tts-utils.ts`) — only matched the exact `time="<digits>ms"` form. Broadened to accept single/double quotes, fractional ms, and the `s` unit.
- **Empty pieces in pause-aware word split** (`tts-utils.ts`) — capturing group emitted empty strings; now skipped.
- **Docstring** (`tts-utils.ts`) — clarified that `<say-as>`/`<sub>`/`<p>`/`<s>` are also stripped, since `markdownToSsml` does not emit them.

## Test plan

- [x] `pnpm --filter server test` — 17 passed (15 prior + 2 new for broader break regex)
- [x] `pnpm --filter web test` — 121 passed; `markdownToSsml` test updated to assert blockquotes no longer start with a break tag
- [x] `pnpm --filter server build` — `dist/` no longer contains any `*.test.js` files
- [x] `pnpm -r lint` — clean
- [x] Manual regression check via small repro scripts:
  - `markdownToSsml('Use the \`[pause]\` token …')` → literal `[pause]` survives conversion; SSML chunk still routed to `markup` (intentional) but `format='text'` user input no longer is
  - `markdownToSsml('> a quote\n\nmore text')` → markup no longer starts with `[pause]`
  - `estimateDuration('Hello world. Goodbye.')` returns 1200 ms vs. prior 2000 ms for the marker-bearing form
  - `ssmlToChirp3Markup` accepts `<break time='1s'/>` and `<break time="0.5s"/>`

## Out of scope (intentionally not fixed)

- The wildcard `<[^>]*>` strip technically also discards `<say-as>`/`<sub>`/`<p>`/`<s>` which Chirp 3 HD documents as supported. `markdownToSsml` doesn't emit those today, so behavior is unchanged in practice; the docstring now notes this.
- Latent: greedy `<[^>]*>` strip is fooled by `>` inside an attribute value. No current producer emits unescaped `>` in attributes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-up (commit `97dcfa7`)

Addresses leftover concerns surfaced during review:

- **Shared `PAUSE_MARKER` regex** — exported from `tts-utils.ts` and reused in `google-speech.ts` so `estimateDuration` no longer duplicates the literal pattern.
- **Cross-reference docstring** on `markdownToSsml`'s `renderNode` — warns future authors that any new SSML tag (other than `<break>`) is stripped to its inner text by the server-side converter, with a pointer to `tts-utils.ts`. Guards against silently shipping e.g. `<say-as>` without coordinated changes.

Skipped: adding a dedicated `google-speech.test.ts` for the `format === 'ssml'` routing branch — the logic is now a one-line ternary, not worth standing up `fetch`/auth-token mocks for.
