### PR TITLE
refactor(voice): memoize toggle in useChapterVoicePlayback (#132)

### DIFF
--- a/apps/web/src/hooks/useChapterVoicePlayback.test.tsx
+++ b/apps/web/src/hooks/useChapterVoicePlayback.test.tsx
@@ -243,4 +243,26 @@ describe('useChapterVoicePlayback', () => {
     expect(result.current.status).toBe('idle');
     expect(mutateAsync).not.toHaveBeenCalled();
   });
+
+  it('keeps a stable `toggle` identity across re-renders', async () => {
+    const { result, rerender } = renderHook(
+      (props: { language: 'de' | 'en'; enabled: boolean }) =>
+        useChapterVoicePlayback({
+          questions: makeQuestions(2),
+          language: props.language,
+          enabled: props.enabled,
+          chapterId: 'c1',
+        }),
+      { initialProps: { language: 'en' as const, enabled: true } },
+    );
+
+    const firstToggle = result.current.toggle;
+
+    // Re-render with changed props and after a state transition.
+    act(() => rerender({ language: 'de', enabled: true }));
+    act(() => result.current.toggle());
+    await flush();
+
+    expect(result.current.toggle).toBe(firstToggle);
+  });
 });

--- a/apps/web/src/hooks/useChapterVoicePlayback.ts
+++ b/apps/web/src/hooks/useChapterVoicePlayback.ts
@@ -1,4 +1,10 @@
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 
 import type { Question, SpeechFormat } from '@athena/api';
 
@@ -74,14 +80,21 @@ export function useChapterVoicePlayback({
 
   const synthesize = trpc.speech.synthesize.useMutation();
 
-  // Refs keep the runner reading fresh values without re-creating itself.
+  // Refs keep the runner — and the stable `toggle` callback — reading fresh
+  // values without re-creating themselves.
   const questionsRef = useRef(questions);
   const languageRef = useRef(language);
   const statusRef = useRef(status);
+  const enabledRef = useRef(enabled);
+  const synthesizeRef = useRef(synthesize);
+  // Holds the latest `run` so the memoized `toggle` never calls a stale runner.
+  const runRef = useRef<(startEpoch: number) => void>(() => {});
   useLayoutEffect(() => {
     questionsRef.current = questions;
     languageRef.current = language;
     statusRef.current = status;
+    enabledRef.current = enabled;
+    synthesizeRef.current = synthesize;
   });
 
   const epochRef = useRef(0);
@@ -164,7 +177,7 @@ export function useChapterVoicePlayback({
     speakingStatus: VoicePlaybackStatus,
   ): Promise<void> => {
     const startEpoch = epochRef.current;
-    const result = await synthesize.mutateAsync({
+    const result = await synthesizeRef.current.mutateAsync({
       text,
       language: languageRef.current,
       format,
@@ -248,8 +261,13 @@ export function useChapterVoicePlayback({
     }
   };
 
-  const toggle = (): void => {
-    if (!enabled) return;
+  // Mirror the freshest `run` so the stable `toggle` below dispatches to it.
+  useLayoutEffect(() => {
+    runRef.current = run;
+  });
+
+  const toggle = useCallback((): void => {
+    if (!enabledRef.current) return;
     const current = statusRef.current;
 
     if (current === 'idle' || current === 'finished' || current === 'error') {
@@ -261,7 +279,7 @@ export function useChapterVoicePlayback({
       pausedRef.current = false;
       setIsPaused(false);
       const startEpoch = ++epochRef.current;
-      void run(startEpoch);
+      void runRef.current(startEpoch);
       return;
     }
 
@@ -293,7 +311,7 @@ export function useChapterVoicePlayback({
       }
       audioRef.current?.pause();
     }
-  };
+  }, []);
 
   // Abort on chapter change and on unmount (single effect covers both).
   useEffect(() => {


### PR DESCRIPTION
## F1 (#132) — memoize `toggle`

`useChapterVoicePlayback` returned `toggle` as a fresh arrow function on every render, so consumers had to exclude it from effect dependency arrays (see the `exhaustive-deps` suppression in `LectureLearn`).

### Change
- Route `run`, `enabled`, and the `synthesize` mutation through refs (mirrored in the existing layout effect), so `toggle` is now a stable `useCallback([])`.
- `toggle` always dispatches to the **latest** `run` via `runRef`, so there is no stale-closure risk on the `run → speak → synthesize` chain (the caveat both review models flagged).
- Added a regression test asserting `toggle`'s identity is stable across re-renders.

### Why a ref for `run`
`run`/`speak` are recreated each render but only read mutable state through refs at call time, so capturing the latest one via `runRef` keeps `toggle` stable **and** current.

### Verification
- `turbo lint --max-warnings=0` ✅
- `tsc && vite build` ✅
- `vitest run` — 122 tests ✅ (incl. new stability test)

Unblocks #134 (removing the `LectureLearn` suppression).

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)