### PR TITLE
refactor(voice): drop exhaustive-deps suppression in LectureLearn (#134)

### DIFF
--- a/apps/web/src/hooks/useChapterVoicePlayback.test.tsx
+++ b/apps/web/src/hooks/useChapterVoicePlayback.test.tsx
@@ -243,4 +243,26 @@ describe('useChapterVoicePlayback', () => {
     expect(result.current.status).toBe('idle');
     expect(mutateAsync).not.toHaveBeenCalled();
   });
+
+  it('keeps a stable `toggle` identity across re-renders', async () => {
+    const { result, rerender } = renderHook(
+      (props: { language: 'de' | 'en'; enabled: boolean }) =>
+        useChapterVoicePlayback({
+          questions: makeQuestions(2),
+          language: props.language,
+          enabled: props.enabled,
+          chapterId: 'c1',
+        }),
+      { initialProps: { language: 'en' as const, enabled: true } },
+    );
+
+    const firstToggle = result.current.toggle;
+
+    // Re-render with changed props and after a state transition.
+    act(() => rerender({ language: 'de', enabled: true }));
+    act(() => result.current.toggle());
+    await flush();
+
+    expect(result.current.toggle).toBe(firstToggle);
+  });
 });

--- a/apps/web/src/hooks/useChapterVoicePlayback.ts
+++ b/apps/web/src/hooks/useChapterVoicePlayback.ts
@@ -1,4 +1,10 @@
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 
 import type { Question, SpeechFormat } from '@athena/api';
 
@@ -74,14 +80,21 @@ export function useChapterVoicePlayback({
 
   const synthesize = trpc.speech.synthesize.useMutation();
 
-  // Refs keep the runner reading fresh values without re-creating itself.
+  // Refs keep the runner — and the stable `toggle` callback — reading fresh
+  // values without re-creating themselves.
   const questionsRef = useRef(questions);
   const languageRef = useRef(language);
   const statusRef = useRef(status);
+  const enabledRef = useRef(enabled);
+  const synthesizeRef = useRef(synthesize);
+  // Holds the latest `run` so the memoized `toggle` never calls a stale runner.
+  const runRef = useRef<(startEpoch: number) => void>(() => {});
   useLayoutEffect(() => {
     questionsRef.current = questions;
     languageRef.current = language;
     statusRef.current = status;
+    enabledRef.current = enabled;
+    synthesizeRef.current = synthesize;
   });
 
   const epochRef = useRef(0);
@@ -164,7 +177,7 @@ export function useChapterVoicePlayback({
     speakingStatus: VoicePlaybackStatus,
   ): Promise<void> => {
     const startEpoch = epochRef.current;
-    const result = await synthesize.mutateAsync({
+    const result = await synthesizeRef.current.mutateAsync({
       text,
       language: languageRef.current,
       format,
@@ -248,8 +261,13 @@ export function useChapterVoicePlayback({
     }
   };
 
-  const toggle = (): void => {
-    if (!enabled) return;
+  // Mirror the freshest `run` so the stable `toggle` below dispatches to it.
+  useLayoutEffect(() => {
+    runRef.current = run;
+  });
+
+  const toggle = useCallback((): void => {
+    if (!enabledRef.current) return;
     const current = statusRef.current;
 
     if (current === 'idle' || current === 'finished' || current === 'error') {
@@ -261,7 +279,7 @@ export function useChapterVoicePlayback({
       pausedRef.current = false;
       setIsPaused(false);
       const startEpoch = ++epochRef.current;
-      void run(startEpoch);
+      void runRef.current(startEpoch);
       return;
     }
 
@@ -293,7 +311,7 @@ export function useChapterVoicePlayback({
       }
       audioRef.current?.pause();
     }
-  };
+  }, []);
 
   // Abort on chapter change and on unmount (single effect covers both).
   useEffect(() => {

--- a/apps/web/src/pages/LectureLearn.tsx
+++ b/apps/web/src/pages/LectureLearn.tsx
@@ -231,11 +231,8 @@ export const LectureLearn = () => {
     } else {
       pendingAutoStartRef.current = false;
     }
-    // `voiceToggle` is deliberately excluded from the deps: the voice hook
-    // returns a fresh `toggle` identity on every render, so including it would
-    // re-run this effect constantly. Its behavior is stable and it is invoked
-    // exactly once per resume (right after the pending flag is cleared).
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // `voiceToggle` now has a stable identity (memoized in the voice hook), so
+    // it can be a real dependency without re-running this effect every render.
   }, [
     voiceStatus,
     autoAdvance,
@@ -246,6 +243,7 @@ export const LectureLearn = () => {
     chapters,
     id,
     navigate,
+    voiceToggle,
   ]);
 
   if (lectureQuery.isLoading || chaptersQuery.isLoading) {


### PR DESCRIPTION
## F5 (#134) — remove blanket `exhaustive-deps` suppression

The auto-advance effect in `LectureLearn` disabled `react-hooks/exhaustive-deps` solely to exclude the previously-unstable `voiceToggle`. That blanket suppression silenced dependency checking for the **entire** ~10-dependency effect.

### Change
- Remove the `eslint-disable-next-line react-hooks/exhaustive-deps`.
- Add `voiceToggle` (now stable thanks to #132) to the dependency array.
- ESLint lints the full effect again — verified with `eslint --no-inline-config` that no other deps were being masked.

> ⚠️ **Stacked on #132** (base branch `fix/132-memoize-voice-toggle`). It depends on `voiceToggle` being memoized; merge/rebase #132 first. GitHub will retarget this PR to `main` automatically once #132 merges.

### Verification
- `turbo lint --max-warnings=0` ✅
- `tsc && vite build` ✅
- `vitest run` — 122 tests ✅

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)