### PR TITLE
build(eslint-config): use canonical flat-config react-hooks accessor (#136)

### DIFF
--- a/packages/eslint-config/react.js
+++ b/packages/eslint-config/react.js
@@ -35,7 +35,11 @@ export const config = [
     },
     rules: {
       ...react.configs.recommended.rules,
-      ...reactHooks.configs.recommended.rules,
+      // Flat-config namespace for eslint-plugin-react-hooks v7. Equivalent rule
+      // set to the legacy `configs.recommended.rules` accessor (verified), but
+      // the canonical path for flat config — and deliberately not
+      // `recommended-latest`, which pulls in newer/experimental rules.
+      ...reactHooks.configs.flat.recommended.rules,
       "react-refresh/only-export-components": [
         "warn",
         { allowConstantExport: true },


### PR DESCRIPTION
## F3 (#136) — canonical react-hooks flat-config accessor

`packages/eslint-config/react.js` spread `reactHooks.configs.recommended.rules`, a non-canonical path for eslint-plugin-react-hooks **v7** flat config.

### Change
Switch to `reactHooks.configs.flat.recommended.rules` — the canonical flat-config namespace.

### Verified empirically (per the issue's request to introspect before changing)
Introspected the installed plugin (7.1.1):
- `configs.flat.recommended.rules` is **identical** to `configs.recommended.rules` — same 16 rules, same severities.
- Deliberately **not** `configs['recommended-latest']`, which adds newer/experimental rules (e.g. `void-use-memo`) — exactly the concern raised in the codex cross-check.

`eslint --no-inline-config` on `apps/web` reports the identical 9 diagnostics as before, and `eslint --print-config` confirms the v7 rules (`refs`, `preserve-manual-memoization`, `set-state-in-effect`) remain active at error level.

### Verification
- `turbo lint --max-warnings=0` ✅ (unchanged rule set)

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)