### PR TITLE
test(voice): guard in-effect ref mirroring in useChapterVoicePlayback (#133)

### DIFF
--- a/apps/web/src/hooks/useChapterVoicePlayback.test.tsx
+++ b/apps/web/src/hooks/useChapterVoicePlayback.test.tsx
@@ -265,4 +265,44 @@ describe('useChapterVoicePlayback', () => {
 
     expect(result.current.toggle).toBe(firstToggle);
   });
+
+  it('reads fresh questions/language after a prop update (in-effect ref mirror)', async () => {
+    const { result, rerender } = renderHook(
+      (props: { questions: Question[]; language: 'de' | 'en' }) =>
+        useChapterVoicePlayback({
+          questions: props.questions,
+          language: props.language,
+          enabled: true,
+          chapterId: 'c1',
+        }),
+      {
+        initialProps: { questions: makeQuestions(1), language: 'en' as const },
+      },
+    );
+
+    // Props change after the first render. The runner reads `questions` and
+    // `language` through refs mirrored in a (layout) effect, so it must pick up
+    // the updated values — never the render-0 snapshot (1 question / 'en').
+    act(() => rerender({ questions: makeQuestions(3), language: 'de' }));
+
+    act(() => result.current.toggle());
+    await flush();
+
+    // languageRef is fresh: synthesis is requested in 'de'.
+    expect(mutateAsync).toHaveBeenLastCalledWith(
+      expect.objectContaining({ language: 'de' }),
+    );
+
+    // questionsRef is fresh: advancing past q0 is only possible with the
+    // updated 3-question array (the initial props had a single question).
+    await act(async () => lastAudio().end()); // q0 question
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400);
+    });
+    await act(async () => lastAudio().end()); // q0 answer
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(result.current.currentQuestionIndex).toBe(1);
+  });
 });


### PR DESCRIPTION
## F2 (#133) — render-phase ref writes

### Status: core already resolved on `main`
The render-phase ref writes the audit flagged (`questionsRef.current = ...` etc. directly in the hook body) were **already moved into a layout effect** by commit `d1cdad7` ("sync pnpm.overrides and refactor for eslint-plugin-react-hooks 7.1.1"). `eslint --no-inline-config` confirms there is no `react-hooks/refs` violation in the hook today.

### What this PR adds
A regression test that locks in the behavior the effect-based mirror guarantees: after a prop update, the runner reads the **latest** `questions`/`language` (not the render-0 snapshot). This prevents a silent revert to render-phase writes — or to a stale-snapshot approach — from going unnoticed.

### Verification
- `vitest run` — 122 tests ✅ (incl. new test)
- `turbo lint --max-warnings=0` ✅
- `tsc && vite build` ✅

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)