### PR TITLE
build(eslint-config): error on unused eslint-disable directives (#135)

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -14,6 +14,15 @@ export const config = [
   eslintConfigPrettier,
   ...tseslint.configs.recommended,
   {
+    // Fail on `eslint-disable` directives that no longer suppress anything, so
+    // stale suppressions can't silently accumulate after a plugin/rule upgrade
+    // (exactly how the old react-hooks suppression in EditChapterModal became
+    // dead). The repo is clean of unused directives as of this change.
+    linterOptions: {
+      reportUnusedDisableDirectives: "error",
+    },
+  },
+  {
     plugins: {
       turbo: turboPlugin,
     },


### PR DESCRIPTION
## F4 (#135) — `preserve-manual-memoization` suppression

### Status: core already resolved on `main`
The `// eslint-disable-next-line react-hooks/preserve-manual-memoization` at `EditChapterModal.tsx:146` was **already removed** by commit `d1cdad7` ("sync pnpm.overrides and refactor for eslint-plugin-react-hooks 7.1.1"). `handleSave` is now a clean `useCallback([association, onSave])` with no suppression, and `eslint --no-inline-config` reports no `preserve-manual-memoization` problem there. As the codex cross-check warned, the memoization was **not** dropped — it's preserved.

### What this PR adds
A systemic guard against the *class* of problem F4 represents: a suppression that silently goes dead after a plugin/rule upgrade. Adds `linterOptions.reportUnusedDisableDirectives: "error"` to the shared base config, so any future stale `eslint-disable` fails the build — independent of the `--max-warnings` flag.

### Verification
- `turbo lint --max-warnings=0` ✅ (repo is clean of unused directives)
- Confirmed enforcement: a probe file with a stale `eslint-disable` now errors with `Unused eslint-disable directive`.

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)