### PR TITLE
fix(buttons): align ExpandableButton split-button styling

### DIFF
--- a/apps/web/src/components/buttons/Button.tsx
+++ b/apps/web/src/components/buttons/Button.tsx
@@ -14,9 +14,9 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
 
 const variantClasses: Record<ButtonVariant, string> = {
   primary:
-    'bg-accent text-accent-ink hover:bg-accent-press shadow-[0_8px_18px_-10px_rgb(var(--shadow-color)/0.7)] hover:shadow-[0_12px_24px_-10px_rgb(var(--shadow-color)/0.75)]',
+    'bg-accent text-accent-ink hover:bg-accent-press shadow-elevate hover:shadow-elevate-raised',
   secondary:
-    'bg-accent-soft text-accent-soft-ink hover:bg-[color-mix(in_oklab,var(--accent-soft)_80%,var(--accent))]',
+    'bg-accent-soft text-accent-soft-ink hover:bg-accent-soft-hover',
   ghost:
     'border border-border text-ink-soft hover:bg-surface-2 hover:text-ink disabled:opacity-40',
   danger: 'bg-danger text-danger-ink hover:bg-danger-press',

--- a/apps/web/src/components/buttons/Button.tsx
+++ b/apps/web/src/components/buttons/Button.tsx
@@ -15,8 +15,7 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
 const variantClasses: Record<ButtonVariant, string> = {
   primary:
     'bg-accent text-accent-ink hover:bg-accent-press shadow-elevate hover:shadow-elevate-raised',
-  secondary:
-    'bg-accent-soft text-accent-soft-ink hover:bg-accent-soft-hover',
+  secondary: 'bg-accent-soft text-accent-soft-ink hover:bg-accent-soft-hover',
   ghost:
     'border border-border text-ink-soft hover:bg-surface-2 hover:text-ink disabled:opacity-40',
   danger: 'bg-danger text-danger-ink hover:bg-danger-press',

--- a/apps/web/src/components/buttons/ExpandableButton.test.tsx
+++ b/apps/web/src/components/buttons/ExpandableButton.test.tsx
@@ -218,6 +218,72 @@ describe('ExpandableButton', () => {
     expect(toggle).not.toHaveClass('hover:bg-accent-press');
   });
 
+  // Every variant shares the same group-hover highlight on both halves, using
+  // the token that matches its main-button hover (Button.tsx).
+  it.each([
+    ['primary', 'group-hover/split:bg-accent-press'],
+    ['secondary', 'group-hover/split:bg-accent-soft-hover'],
+    ['ghost', 'group-hover/split:bg-surface-2'],
+    ['danger', 'group-hover/split:bg-danger-press'],
+  ] as const)(
+    'shares the %s group-hover highlight across both halves',
+    (variant, highlight) => {
+      const actions = [{ label: 'Randomized', onClick: vi.fn() }];
+      render(
+        <ExpandableButton onClick={vi.fn()} actions={actions} variant={variant}>
+          Train
+        </ExpandableButton>,
+      );
+
+      expect(screen.getByTestId('expandable-button-main')).toHaveClass(
+        highlight,
+      );
+      expect(screen.getByTestId('expandable-button-dropdown')).toHaveClass(
+        highlight,
+      );
+    },
+  );
+
+  it('carries the elevation shadow on the split wrapper, not the inner button', () => {
+    const actions = [{ label: 'Randomized', onClick: vi.fn() }];
+    render(
+      <ExpandableButton onClick={vi.fn()} actions={actions}>
+        Train
+      </ExpandableButton>,
+    );
+
+    // Wrapper owns the resting + hover-grown shadow; the inner button suppresses
+    // its own so the two don't double up.
+    const split = screen.getByTestId('expandable-button-split');
+    expect(split).toHaveClass(
+      'shadow-elevate',
+      'group-hover/split:shadow-elevate-raised',
+    );
+    expect(screen.getByTestId('expandable-button-main')).toHaveClass(
+      'shadow-none!',
+    );
+  });
+
+  it('drops the wrapper shadow and hover highlight when disabled', () => {
+    const actions = [{ label: 'Randomized', onClick: vi.fn() }];
+    render(
+      <ExpandableButton onClick={vi.fn()} actions={actions} disabled>
+        Train
+      </ExpandableButton>,
+    );
+
+    // The wrapper has no disabled state of its own, so a disabled button must not
+    // keep a full-strength shadow or react to hover.
+    const split = screen.getByTestId('expandable-button-split');
+    expect(split).not.toHaveClass('shadow-elevate');
+    expect(screen.getByTestId('expandable-button-main')).not.toHaveClass(
+      'group-hover/split:bg-accent-press',
+    );
+    expect(screen.getByTestId('expandable-button-dropdown')).not.toHaveClass(
+      'group-hover/split:bg-accent-press',
+    );
+  });
+
   it('disables individual action when action.disabled is true', () => {
     const disabledAction = vi.fn();
     const actions = [

--- a/apps/web/src/components/buttons/ExpandableButton.test.tsx
+++ b/apps/web/src/components/buttons/ExpandableButton.test.tsx
@@ -175,6 +175,49 @@ describe('ExpandableButton', () => {
     expect(mainButton.className).toContain('bg-danger');
   });
 
+  it('colors the primary toggle and menu with the accent fill, not the ink token', () => {
+    const actions = [{ label: 'Randomized', onClick: vi.fn() }];
+    render(
+      <ExpandableButton onClick={vi.fn()} actions={actions}>
+        Train
+      </ExpandableButton>,
+    );
+
+    // Toggle shares the main button's accent fill and nudges on press.
+    const toggle = screen.getByTestId('expandable-button-dropdown');
+    expect(toggle).toHaveClass('bg-accent', 'active:translate-y-px');
+    expect(toggle).not.toHaveClass('bg-primary-700');
+
+    // Open the menu and check the panel + first action.
+    fireEvent.click(toggle);
+
+    const menu = screen.getByTestId('expandable-button-menu');
+    expect(menu).toHaveClass('bg-accent');
+    expect(menu).not.toHaveClass('bg-primary-700');
+
+    // Action items carry only the text/hover accent tokens (no bg-accent).
+    const action = screen.getByTestId('expandable-button-action-0');
+    expect(action).toHaveClass('text-accent-ink', 'hover:bg-accent-press');
+    expect(action).not.toHaveClass('hover:bg-primary-800');
+  });
+
+  it('highlights both halves on hover of either (shared group-hover)', () => {
+    const actions = [{ label: 'Randomized', onClick: vi.fn() }];
+    render(
+      <ExpandableButton onClick={vi.fn()} actions={actions}>
+        Train
+      </ExpandableButton>,
+    );
+
+    // Both halves carry the group-scoped highlight, so hovering either lights up
+    // both. The toggle no longer carries a self-only `hover:bg-*`.
+    const main = screen.getByTestId('expandable-button-main');
+    const toggle = screen.getByTestId('expandable-button-dropdown');
+    expect(main).toHaveClass('group-hover/split:bg-accent-press');
+    expect(toggle).toHaveClass('group-hover/split:bg-accent-press');
+    expect(toggle).not.toHaveClass('hover:bg-accent-press');
+  });
+
   it('disables individual action when action.disabled is true', () => {
     const disabledAction = vi.fn();
     const actions = [

--- a/apps/web/src/components/buttons/ExpandableButton.tsx
+++ b/apps/web/src/components/buttons/ExpandableButton.tsx
@@ -107,48 +107,62 @@ export const ExpandableButton = ({
     danger: 'border-red-400/30',
   };
 
+  // Hovering either half highlights both. These match each variant's main-button
+  // hover color (Button.tsx) so the two halves share one highlight.
+  const splitHoverClasses: Record<ButtonVariant, string> = {
+    primary: 'group-hover/split:bg-accent-press',
+    secondary:
+      'group-hover/split:bg-[color-mix(in_oklab,var(--accent-soft)_80%,var(--accent))]',
+    ghost: 'group-hover/split:bg-surface-2',
+    danger: 'group-hover/split:bg-danger-press',
+  };
+
   return (
     <div ref={containerRef} className={`relative flex ${className}`}>
-      {/* Main button */}
-      <Button
-        variant={variant}
-        disabled={disabled}
-        onClick={handleMainClick}
-        className={`rounded-r-none! pr-3! flex-1 ${buttonClassName}`}
-        data-testid="expandable-button-main"
-      >
-        {children}
-      </Button>
+      {/* Button row — hovering either half highlights both (group/split) */}
+      <div className="group/split flex flex-1">
+        {/* Main button */}
+        <Button
+          variant={variant}
+          disabled={disabled}
+          onClick={handleMainClick}
+          className={`rounded-r-none! pr-3! flex-1 ${splitHoverClasses[variant]} ${buttonClassName}`}
+          data-testid="expandable-button-main"
+        >
+          {children}
+        </Button>
 
-      {/* Dropdown trigger */}
-      <button
-        type="button"
-        disabled={disabled}
-        onClick={handleToggleDropdown}
-        aria-label={dropdownLabel}
-        aria-haspopup="true"
-        aria-expanded={isOpen}
-        className={`
-          flex items-center justify-center px-2
-          border-l-2 ${dropdownBorderClasses[variant]}
-          rounded-r-lg transition-all duration-200
-          ${
-            variant === 'primary'
-              ? 'bg-primary-700 text-on-primary hover:bg-primary-800 active:bg-primary-900'
-              : ''
-          }
-          ${variant === 'secondary' ? 'bg-primary-50 text-primary-600 hover:bg-primary-200 active:bg-primary-300' : ''}
-          ${variant === 'ghost' ? 'text-primary-600 hover:bg-primary-100 active:bg-primary-200' : ''}
-          ${variant === 'danger' ? 'bg-red-600 text-on-primary hover:bg-red-700 active:bg-red-800' : ''}
-          disabled:opacity-50 disabled:cursor-not-allowed
-        `}
-        data-testid="expandable-button-dropdown"
-      >
-        <ChevronDown
-          size={16}
-          className={`transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}`}
-        />
-      </button>
+        {/* Dropdown trigger */}
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={handleToggleDropdown}
+          aria-label={dropdownLabel}
+          aria-haspopup="true"
+          aria-expanded={isOpen}
+          className={`
+            flex items-center justify-center px-2
+            border-l-2 ${dropdownBorderClasses[variant]}
+            rounded-r-lg transition-all duration-200
+            ${splitHoverClasses[variant]}
+            ${
+              variant === 'primary'
+                ? 'bg-accent text-accent-ink active:translate-y-px'
+                : ''
+            }
+            ${variant === 'secondary' ? 'bg-primary-50 text-primary-600 active:bg-primary-300' : ''}
+            ${variant === 'ghost' ? 'text-primary-600 active:bg-primary-200' : ''}
+            ${variant === 'danger' ? 'bg-red-600 text-on-primary active:bg-red-800' : ''}
+            disabled:opacity-50 disabled:cursor-not-allowed
+          `}
+          data-testid="expandable-button-dropdown"
+        >
+          <ChevronDown
+            size={16}
+            className={`transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}`}
+          />
+        </button>
+      </div>
 
       {/* Dropdown menu */}
       {isOpen && actions.length > 0 && (
@@ -160,7 +174,7 @@ export const ExpandableButton = ({
             w-full font-semibold
             rounded-lg shadow-sm
             animate-in fade-in slide-in-from-top-1 duration-150
-            ${variant === 'primary' ? 'bg-primary-700 border border-primary-600' : ''}
+            ${variant === 'primary' ? 'bg-accent border border-accent-press' : ''}
             ${variant === 'secondary' ? 'bg-primary-50 border border-primary-200' : ''}
             ${variant === 'ghost' ? 'bg-surface border border-border' : ''}
             ${variant === 'danger' ? 'bg-red-600 border border-red-500' : ''}
@@ -179,7 +193,7 @@ export const ExpandableButton = ({
                 first:rounded-t-lg last:rounded-b-lg
                 disabled:opacity-50 disabled:cursor-not-allowed
                 transition-colors duration-150
-                ${variant === 'primary' ? 'text-on-primary hover:bg-primary-800' : ''}
+                ${variant === 'primary' ? 'text-accent-ink hover:bg-accent-press' : ''}
                 ${variant === 'secondary' ? 'text-primary-700 hover:bg-primary-100' : ''}
                 ${variant === 'ghost' ? 'text-ink-soft hover:bg-primary-50' : ''}
                 ${variant === 'danger' ? 'text-on-primary hover:bg-red-700' : ''}

--- a/apps/web/src/components/buttons/ExpandableButton.tsx
+++ b/apps/web/src/components/buttons/ExpandableButton.tsx
@@ -117,16 +117,30 @@ export const ExpandableButton = ({
     danger: 'group-hover/split:bg-danger-press',
   };
 
+  // The primary main button carries an elevation shadow (Button.tsx). Lift it onto
+  // the whole split wrapper so it spans both halves and grows on hovering either;
+  // the inner button's own shadow is suppressed below to avoid doubling it.
+  const splitShadowClasses: Record<ButtonVariant, string> = {
+    primary:
+      'shadow-[0_8px_18px_-10px_rgb(var(--shadow-color)/0.7)] group-hover/split:shadow-[0_12px_24px_-10px_rgb(var(--shadow-color)/0.75)] transition-shadow duration-200',
+    secondary: '',
+    ghost: '',
+    danger: '',
+  };
+
   return (
     <div ref={containerRef} className={`relative flex ${className}`}>
-      {/* Button row — hovering either half highlights both (group/split) */}
-      <div className="group/split flex flex-1">
-        {/* Main button */}
+      {/* Button row — hovering either half highlights both (group/split); the
+          shadow lives here so it spans both halves and grows on either hover. */}
+      <div
+        className={`group/split flex flex-1 rounded-lg ${splitShadowClasses[variant]}`}
+      >
+        {/* Main button — own shadow suppressed; the wrapper carries it instead */}
         <Button
           variant={variant}
           disabled={disabled}
           onClick={handleMainClick}
-          className={`rounded-r-none! pr-3! flex-1 ${splitHoverClasses[variant]} ${buttonClassName}`}
+          className={`rounded-r-none! pr-3! flex-1 shadow-none! ${splitHoverClasses[variant]} ${buttonClassName}`}
           data-testid="expandable-button-main"
         >
           {children}

--- a/apps/web/src/components/buttons/ExpandableButton.tsx
+++ b/apps/web/src/components/buttons/ExpandableButton.tsx
@@ -107,40 +107,46 @@ export const ExpandableButton = ({
     danger: 'border-red-400/30',
   };
 
-  // Hovering either half highlights both. These match each variant's main-button
-  // hover color (Button.tsx) so the two halves share one highlight.
+  // Hovering either half highlights both. These reuse each variant's main-button
+  // hover token (Button.tsx) so the two halves share one highlight; suppressed
+  // when disabled so a dead button doesn't react to hover.
   const splitHoverClasses: Record<ButtonVariant, string> = {
     primary: 'group-hover/split:bg-accent-press',
-    secondary:
-      'group-hover/split:bg-[color-mix(in_oklab,var(--accent-soft)_80%,var(--accent))]',
+    secondary: 'group-hover/split:bg-accent-soft-hover',
     ghost: 'group-hover/split:bg-surface-2',
     danger: 'group-hover/split:bg-danger-press',
   };
+  const splitHover = disabled ? '' : splitHoverClasses[variant];
 
-  // The primary main button carries an elevation shadow (Button.tsx). Lift it onto
-  // the whole split wrapper so it spans both halves and grows on hovering either;
-  // the inner button's own shadow is suppressed below to avoid doubling it.
+  // The primary main button carries an elevation shadow (Button.tsx, via the
+  // shared shadow-elevate token). Lift it onto the whole split wrapper so it
+  // spans both halves and grows on hovering either; the inner button's own
+  // shadow is suppressed below to avoid doubling it. Dropped when disabled so the
+  // dead button reads flat (and never casts a full-strength shadow under its
+  // dimmed halves, since the wrapper has no disabled:opacity of its own).
   const splitShadowClasses: Record<ButtonVariant, string> = {
     primary:
-      'shadow-[0_8px_18px_-10px_rgb(var(--shadow-color)/0.7)] group-hover/split:shadow-[0_12px_24px_-10px_rgb(var(--shadow-color)/0.75)] transition-shadow duration-200',
+      'shadow-elevate group-hover/split:shadow-elevate-raised transition-shadow duration-200',
     secondary: '',
     ghost: '',
     danger: '',
   };
+  const splitShadow = disabled ? '' : splitShadowClasses[variant];
 
   return (
     <div ref={containerRef} className={`relative flex ${className}`}>
       {/* Button row — hovering either half highlights both (group/split); the
           shadow lives here so it spans both halves and grows on either hover. */}
       <div
-        className={`group/split flex flex-1 rounded-lg ${splitShadowClasses[variant]}`}
+        className={`group/split flex flex-1 rounded-lg ${splitShadow}`}
+        data-testid="expandable-button-split"
       >
         {/* Main button — own shadow suppressed; the wrapper carries it instead */}
         <Button
           variant={variant}
           disabled={disabled}
           onClick={handleMainClick}
-          className={`rounded-r-none! pr-3! flex-1 shadow-none! ${splitHoverClasses[variant]} ${buttonClassName}`}
+          className={`rounded-r-none! pr-3! flex-1 shadow-none! ${splitHover} ${buttonClassName}`}
           data-testid="expandable-button-main"
         >
           {children}
@@ -158,7 +164,7 @@ export const ExpandableButton = ({
             flex items-center justify-center px-2
             border-l-2 ${dropdownBorderClasses[variant]}
             rounded-r-lg transition-all duration-200
-            ${splitHoverClasses[variant]}
+            ${splitHover}
             ${
               variant === 'primary'
                 ? 'bg-accent text-accent-ink active:translate-y-px'

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -29,7 +29,11 @@
   --accent-soft-ink: oklch(0.44 0.12 305);
   /* Secondary-button hover fill. Derived from the two tokens above, so it flips
      with them in dark mode — define once. Shared by Button + ExpandableButton. */
-  --accent-soft-hover: color-mix(in oklab, var(--accent-soft) 80%, var(--accent));
+  --accent-soft-hover: color-mix(
+    in oklab,
+    var(--accent-soft) 80%,
+    var(--accent)
+  );
   --success: oklch(0.6 0.1 150);
   --success-soft: oklch(0.93 0.04 150);
   --danger: oklch(0.55 0.18 25);

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -27,6 +27,9 @@
   --accent-ink: oklch(0.99 0.01 310);
   --accent-soft: oklch(0.93 0.045 308);
   --accent-soft-ink: oklch(0.44 0.12 305);
+  /* Secondary-button hover fill. Derived from the two tokens above, so it flips
+     with them in dark mode — define once. Shared by Button + ExpandableButton. */
+  --accent-soft-hover: color-mix(in oklab, var(--accent-soft) 80%, var(--accent));
   --success: oklch(0.6 0.1 150);
   --success-soft: oklch(0.93 0.04 150);
   --danger: oklch(0.55 0.18 25);
@@ -90,6 +93,7 @@
   --color-accent-ink: var(--accent-ink);
   --color-accent-soft: var(--accent-soft);
   --color-accent-soft-ink: var(--accent-soft-ink);
+  --color-accent-soft-hover: var(--accent-soft-hover);
   --color-border: var(--border);
   --color-border-soft: var(--border-soft);
   --color-success: var(--success);
@@ -190,6 +194,11 @@
     0 12px 28px -6px rgb(var(--shadow-color) / 0.1),
     0 4px 10px -6px rgb(var(--shadow-color) / 0.07);
   --shadow-2xl: 0 20px 44px -10px rgb(var(--shadow-color) / 0.14);
+
+  /* Raised elevation for the primary Button and the ExpandableButton split
+     wrapper — single source so the two stay in sync (rest + hover-grown). */
+  --shadow-elevate: 0 8px 18px -10px rgb(var(--shadow-color) / 0.7);
+  --shadow-elevate-raised: 0 12px 24px -10px rgb(var(--shadow-color) / 0.75);
 }
 
 @layer base {


### PR DESCRIPTION
## Summary

The split "Train" button (`ExpandableButton`) had three visual issues where the chevron toggle half didn't match the main button. This branch fixes all three and adds regression tests.

- **Color mismatch** — the toggle and open dropdown menu used `bg-primary-700`, which maps to the `--accent-soft-ink` ink/text token rather than a fill, so they rendered darker (light theme) / lighter (dark theme) than the main button. Recolored the primary toggle, menu panel, and menu items to `bg-accent` / `text-accent-ink` / `accent-press` to match.
- **Hover only lit one half** — wrapped both halves in a `group/split` so hovering either the "Train" side or the chevron highlights the whole button together. Per-variant highlight map keeps secondary/ghost/danger coherent too.
- **Shadow only on the left** — the elevation shadow was baked into the main `<Button>`, so the arrow side cast none and hovering it didn't grow it. Lifted the resting + hover shadow onto the `group/split` wrapper (spans both halves, grows on either hover) and suppressed the inner button's own shadow to avoid doubling.
- Added `active:translate-y-px` to the toggle for press parity with the main half.

## Testing

- `pnpm test --run ExpandableButton` — 17 passing, including new regression tests asserting the accent tokens (via the tokenized `toHaveClass` matcher, not the leaky `.toContain`) and the shared `group-hover/split` highlight.
- `pnpm exec tsc --noEmit` — clean.
- Manually verified resting/hover/press in both light and dark themes.

## Notes

- The `danger` variant has an analogous (cosmetically invisible) text-token divergence that is intentionally left for a separate change — only `primary` was in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)